### PR TITLE
DAG-1693: Add integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.1 - 2022-03-22
+
+* Add integration testing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +136,17 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
 
 [[package]]
 name = "bumpalo"
@@ -381,6 +406,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223089cd5a4e4491f0a0dddd9933f9575123160cf96ca2bb56a690046ecf1745"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "duct"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +546,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -979,9 +1022,10 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "cargo-nextest",
  "chrono",
@@ -997,6 +1041,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shrub-rs",
+ "tempdir",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1285,6 +1330,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1419,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1499,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1465,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -1776,6 +1891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1922,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
@@ -2109,6 +2240,15 @@ checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mongo-task-generator"
-version = "0.1.0"
+version = "0.1.1"
+repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"
 
@@ -24,8 +25,10 @@ tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["json", "fmt", "std"]}
 
 [dev-dependencies]
+assert_cmd = "2.0"
 cargo-nextest = "0.9"
-rstest = "0.11"
+rstest = "0.12"
+tempdir = "0.3"
 
 [profile.release]
 opt-level = 2

--- a/evergreen.landscape.yml
+++ b/evergreen.landscape.yml
@@ -8,11 +8,15 @@ buildvariants:
       - name: unit_tests
       - name: lint
       - name: format
+      - name: check_version
 
 bonsai:
   - source: github
     owner: dbradf
     repo: evg-bonsai-rust
+  - source: github
+    owner: dbradf
+    repo: evg-bonsai-version-check
 
 pre:
   - command: git.get_project
@@ -56,4 +60,11 @@ tasks:
       params:
         target_dir: src
         cargo_command: build
-
+  
+  - name: check_version
+    commands:
+    - bonsai: version-check:run
+      params:
+        target_dir: src
+        package_type: rust
+        publish_type: github-release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1,5 +1,5 @@
 # Generated from bonsai
-# Generated at: 2022-03-02 21:01:33.627389 UTC
+# Generated at: 2022-03-22 19:48:24.600743 UTC
 ---
 buildvariants:
   - name: ubuntu1804
@@ -8,6 +8,7 @@ buildvariants:
       - name: unit_tests
       - name: lint
       - name: format
+      - name: check_version
     display_name: Ubuntu 18.04
     run_on:
       - ubuntu1804-test
@@ -28,27 +29,38 @@ tasks:
     commands:
       - func: cargo_run
         vars:
-          target_dir: src
           cargo_command: clippy -- -D warnings
+          target_dir: src
   - name: build
     commands:
       - func: cargo_run
         vars:
           target_dir: src
           cargo_command: build
+  - name: check_version
+    commands:
+      - func: version-check_run
+        vars:
+          package_type: rust
+          publish_type: github-release
+          target_dir: src
 functions:
   cargo_enable nextest:
     - command: shell.exec
       params:
         script: "set -o errexit\n\nexport RUSTUP_HOME=\"$PWD/bonsai/rustup\"\nexport CARGO_HOME=\"$PWD/bonsai/cargo\"\nexport PATH=\"$PATH:$CARGO_HOME/bin\"\n\ncurl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C \"$CARGO_HOME/bin\"\n"
+  cargo_run:
+    - command: shell.exec
+      params:
+        script: "set -o errexit\n\nexport RUSTUP_HOME=\"$PWD/bonsai/rustup\"\nexport CARGO_HOME=\"$PWD/bonsai/cargo\"\nexport PATH=\"$PATH:$CARGO_HOME/bin:$HOME:/\"\n\ncd ${target_dir}\n\ncargo ${cargo_command}\n"
   cargo_install rust:
     - command: shell.exec
       params:
         script: "set -o errexit\n\nexport RUSTUP_HOME=\"$PWD/bonsai/rustup\"\nexport CARGO_HOME=\"$PWD/bonsai/cargo\"\nexport PATH=\"$PATH:$CARGO_HOME/bin\"\ncurl https://sh.rustup.rs -sSf | sh -s -- -y\nrustup default ${rust_version}\n"
-  cargo_run:
+  version-check_run:
     - command: shell.exec
       params:
-        script: "set -o errexit\n\nexport RUSTUP_HOME=\"$PWD/bonsai/rustup\"\nexport CARGO_HOME=\"$PWD/bonsai/cargo\"\nexport PATH=\"$PATH:$CARGO_HOME/bin\"\n\ncd ${target_dir}\n\ncargo ${cargo_command}\n"
+        script: "set -o errexit\n\nif [ \"${is_patch}\" = \"true\" ]; then\n  wget -q https://github.com/dbradf/pypi-version-check/releases/download/v0.3.0/pypi-version-check\n  chmod +x pypi-version-check\n  ./pypi-version-check --package-type ${package_type} --publish-type ${publish_type} --project-path ${target_dir} --check-changelog\nfi\n"
 pre:
   - command: git.get_project
     params:

--- a/tests/data/evergreen.yml
+++ b/tests/data/evergreen.yml
@@ -1,0 +1,12762 @@
+####################################################
+#                  YAML Conventions                 #
+#####################################################
+# Please see our conventions document at
+# https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=133273894
+# for help navigating this document, or for help with our lint rules.
+
+
+#####################################################
+#               A note on expansions                #
+#####################################################
+
+# Expansions usually appear in the form ${key|default}
+# If 'key' is found in the executor's map of currently known
+# expansions, the corresponding value is used. If the key can
+# not be found, the default is used.
+#
+# Arbitrary expansions can be specified in the YAML configuration
+# files in the following places:
+# - The 'expansions' field for buildvariants (branch file)
+# - The 'expansions' field for distros (distros file)
+#
+# A number of 'built-in' expansions are also available for use; these include:
+# - environment variables available on the host machine
+# - 'workdir' (references the executor's work directory).
+# - 'task_id' (references the task id of the task the executor is working on).
+# - 'build_variant' (references the executing task's buildvariant).
+# - 'config_root' (references the root directory for the executor's configuration artifacts).
+
+
+#####################################################
+#          Setup environment in a new task          #
+#####################################################
+
+# There are several ways to setup the environment in your task.
+#
+# 1. If your task depends on 'archive_dist_test'/'archive_dist_test_debug' task you can call the function "do setup"
+# - func: "do setup"
+# Or alternatively call the functions in the sequence below, if you don't need everything else from "do setup"
+# - func: "fetch artifacts" (includes python, shell scripts, jstests etc. from the mongo and enterprise repos)
+# - func: "f_expansions_write"
+# - func: "kill processes"
+# - func: "cleanup environment"
+# - func: "set up venv"
+#
+# 2. If your task does not depend on 'archive_dist_test'/'archive_dist_test_debug' task use the following functions
+# call sequence
+# - command: manifest.load
+# - func: "git get project" (clone the entire mongo and enterprise repos)
+# - func: "f_expansions_write"
+# - func: "kill processes"
+# - func: "cleanup environment"
+# - func: "set up venv"
+
+
+stepback: true
+command_type: system
+pre_error_fails_task: true
+oom_tracker: true
+
+
+# Files that match an ignore-list pattern will not trigger a build, if they're the only modified
+# files in the patch.
+ignore:
+  - ".*"
+  - "!.clang-format"
+  - "!.eslintrc.yml"
+  - "*.md"
+  - "*.rst"
+  - "*.txt"
+  - "/distsrc/**"
+  - "/docs/**"
+  - "/etc/*.yml"
+  - "!/etc/evergreen.yml"
+  - "README"
+
+## Parameters for parameterized builds (see https://github.com/evergreen-ci/evergreen/wiki/Parameterized-Builds)
+parameters:
+  - key: patch_compile_flags
+    description: "Additional SCons flags to be applied during scons compile invocations in this patch"
+
+  - key: future_git_tag
+    description: "Future git tag to be added. If empty, we will use the most recent git tag instead."
+
+  - key: last_lts_evg_version_id
+    description: "The Evergreen Version ID of the last-lts MongoDB binaries. Only binaries from release variants are used"
+
+  - key: last_continuous_evg_version_id
+    description: "The Evergreen Version ID of the last-continuous MongoDB binaries. Only binaries from release variants are used"
+
+  - key: antithesis_image_tag
+    description: "The docker tag to use when pushing images to Antithesis"
+
+  - key: burn_in_tests
+    description: "Comma separated list of jstests to include when running burn_in_tests"
+
+## Some variables for convenience:
+variables:
+
+# Used when the tests it runs depend only on mongod, mongos, the mongo shell and the tools.
+- &task_template
+  name: template
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_args: --help
+      resmoke_jobs_max: 0  # No cap on number of jobs.
+
+- &gen_task_template
+  name: gen_task_template
+  depends_on:
+    - name: build_variant_gen
+    - name: archive_dist_test
+  commands:
+    - func: "generate resmoke tasks"
+      vars:
+        resmoke_args: --help
+
+- &benchmark_template
+  name: benchmark_template
+  depends_on:
+  - name: compile_benchmarks
+  commands:
+  - func: "do benchmark setup"
+  - func: "run tests"
+    vars:
+      resmoke_args: --help
+      resmoke_jobs_max: 1
+  - func: "send benchmark results"
+  - func: "analyze benchmark results"
+    vars:
+      suite: benchmark_suite
+
+- &jepsen_config_vars
+  jepsen_key_time_limit: --key-time-limit 15
+  jepsen_protocol_version: --protocol-version 1
+  jepsen_read_concern: ""
+  jepsen_read_with_find_and_modify: ""
+  jepsen_storage_engine: ""
+  jepsen_test_name: ""
+  # Empirically, we've had greater success in reproducing the issues found in MongoDB versions
+  # 3.4.0-rc3 and 3.4.0-rc4 when running Jepsen with at least --time-limit=600.
+  jepsen_time_limit: --time-limit 1200
+  jepsen_write_concern: ""
+
+# Template for running Jepsen tests
+- &run_jepsen_template
+  name: run_jepsen_template
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "do jepsen setup"
+  - func: "run jepsen test"
+    vars:
+      <<: *jepsen_config_vars
+
+- &jstestfuzz_config_vars
+  is_jstestfuzz: true
+  num_files: 15
+  num_tasks: 5  # Upperbound by `max_sub_suites` specified through the variant with each task still running `num_files` files.
+  resmoke_args: --help # resmoke_args needs to be overridden to specify one of the jstestfuzz suites
+  resmoke_jobs_max: 1
+  should_shuffle: false
+  continue_on_failure: false
+  # Terminate the function when there has been no output to stdout for 30 minutes. E.g. when something is stuck in an infinite loop.
+  # resmoke.py writes the test output to logkeeper and only writes to stdout when starting the next test.
+  # resmoke.py not producing output on stdout means that the test is still running and presumably not going to finish.
+  # Note that timeout_secs is different from exec_timeout_secs, which applies to a task and times out regardless of whether output has been written to stdout.
+  timeout_secs: 1800
+
+# Used for tests that invoke 'resmoke.py --suites=jstestfuzz*'.
+- &jstestfuzz_template
+  name: jstestfuzz_template
+  exec_timeout_secs: 14400 # Time out the task if it runs for more than 4 hours.
+  depends_on:
+  - build_variant_gen
+  - archive_dist_test
+  commands:
+  - func: "generate resmoke tasks"
+
+# Templates used by powercycle
+- &powercycle_remote_credentials
+  private_key_file: src/powercycle.pem
+  private_key_remote: ${__project_aws_ssh_key_value}
+
+- &libfuzzertests
+  name: libfuzzertests!
+  execution_tasks:
+  - compile_and_archive_libfuzzertests
+  - fetch_and_run_libfuzzertests
+
+- &compile_task_group_template
+  name: compile_task_group_template
+  max_hosts: 1
+  tasks: []
+  setup_task:
+  - func: "f_expansions_write"
+  - func: "apply compile expansions"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  teardown_task:
+  - func: "f_expansions_write"
+  - func: "attach scons logs"
+  - func: "attach report"
+  - func: "attach artifacts"
+  - func: "kill processes"
+  - func: "save code coverage data"
+  - func: "save mongo coredumps"
+  - func: "save failed unittests"
+  - func: "save UndoDB recordings"
+  - func: "save unstripped dbtest"
+  - func: "save hang analyzer debugger files"
+  - func: "save disk statistics"
+  - func: "save system resource information"
+  - func: "save libfuzzertest corpora"
+  - func: "remove files"
+    vars:
+      files: >-
+        src/resmoke_error_code
+        src/build/scons/config.log
+        src/*.gcda.gcov
+        src/gcov-intermediate-files.tgz
+        src/*.core src/*.mdmp
+        mongo-coredumps.tgz
+        src/dist-unittests/bin/*
+        src/dist-unittests/lib/*
+        mongo-unittests.tgz
+        src/debugger*.*
+        src/mongo-hanganalyzer.tgz
+        diskstats.tgz
+        system-resource-info.tgz
+        ${report_file|src/report.json}
+        ${archive_file|src/archive.json}
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  - func: "kill processes"
+  - func: "cleanup environment"
+  # The python virtual environment is installed in ${workdir}, which is created in
+  # "set up venv".
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "get all modified patch files"
+  - func: "f_expansions_write"
+  - func: "configure evergreen api credentials"
+  - func: "get buildnumber"
+  - func: "f_expansions_write"
+  - func: "set up credentials"
+  - func: "use WiredTiger develop" # noop if ${use_wt_develop} is not "true"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"
+  - func: "f_expansions_write"
+  teardown_group:
+  - func: "f_expansions_write"
+  - func: "umount shared scons directory"
+  - func: "cleanup environment"
+  timeout:
+  - func: "f_expansions_write"
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
+
+# Use this template for enterprise Windows testing coverage on non-pushing
+# variants
+- &enterprise-windows-nopush-template
+  name: enterprise-windows-nopush-template
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - windows-vsCurrent-small
+  modules:
+  - enterprise
+  expansions: &enterprise-windows-nopush-expansions-template
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug msi
+    exe: ".exe"
+    content_type: application/zip
+    compile_flags: --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(( $(grep -c ^processor /proc/cpuinfo) / 2 )) --win-version-min=win10
+    num_scons_link_jobs_available: 0.5
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    multiversion_platform: windows
+    multiversion_edition: enterprise
+    jstestfuzz_num_generated_files: 35
+    large_distro_name: windows-vsCurrent-large
+    test_flags: --excludeWithAnyTags=incompatible_with_windows_tls
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: build_variant_gen
+  - name: burn_in_tests_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: buildscripts_test
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .csfle
+    distros:
+      - windows-vsCurrent-xlarge
+  - name: .encrypt !.aggregation !.gcm
+  - name: external_auth
+  - name: external_auth_aws
+  - name: external_auth_windows
+    distros:
+    - windows-2016-dc
+  - name: .jscore .common !.sharding
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache
+  - name: replica_sets_auth_gen
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: sharding_auth_audit_gen
+  - name: snmp
+
+- &stitch_support_task_group_template
+  name: stitch_support_task_group_template
+  setup_task:
+    - func: "apply compile expansions"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+  teardown_task:
+  - func: "attach scons logs"
+  setup_group_can_fail_task: true
+  setup_group:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "get buildnumber"
+    - func: "f_expansions_write"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+  teardown_group:
+    - func: "umount shared scons directory"
+
+# List of all variants that make mongocryptd
+# If a variant is listed here and has a push task, mongocryptd is pushed
+- mongocryptd_variants: &mongocryptd_variants
+  - enterprise-amazon2
+  - enterprise-amazon2-arm64
+  - enterprise-debian92-64
+  - enterprise-debian10-64
+  - enterprise-linux-64-amazon-ami
+  - enterprise-macos
+  - enterprise-rhel-70-64-bit
+#  - enterprise-rhel-70-64-bit-kitchen-sink
+  - enterprise-rhel-70-64-bit-no-libunwind
+  - enterprise-rhel-81-ppc64le
+  - enterprise-rhel-72-s390x
+  - enterprise-rhel-80-64-bit
+  - enterprise-rhel-80-64-bit-coverage
+  - enterprise-rhel-80-64-bit-inmem
+  - enterprise-rhel-80-64-bit-multiversion
+  - enterprise-rhel-80-64-bit-suggested
+  - enterprise-rhel-82-arm64
+  - enterprise-suse12-64
+  - enterprise-suse15-64
+  - enterprise-ubuntu1804-64
+  - enterprise-ubuntu1804-arm64
+  - enterprise-ubuntu2004-arm64
+  - enterprise-ubuntu2004-64
+  - enterprise-windows
+  - enterprise-windows-debug-unoptimized
+  - enterprise-windows-inmem
+  - enterprise-windows-required
+  - enterprise-windows-wtdevelop
+  - ubuntu1804-debug-asan
+  - ubuntu1804-debug-ubsan
+  - ubuntu1804-debug-aubsan-lite-required
+  - ubuntu1804-debug-aubsan-lite_fuzzer
+
+
+# List of all variants that make mh artifacts.
+# If a variant is listed here and has a push task, the mh artifacts are pushed
+- mh_variants: &mh_variants
+  - enterprise-debian92-64
+  - enterprise-macos
+  - enterprise-rhel-80-64-bit
+  - enterprise-rhel-80-64-bit-dynamic-required
+  - enterprise-rhel-70-64-bit
+  - enterprise-rhel-82-arm64
+  - enterprise-amazon2-arm64
+  - enterprise-ubuntu1804-64
+  - enterprise-windows
+  - enterprise-windows-required
+
+# List of all variants that use the packages.tgz
+- package_variants: &package_variants
+  - amazon
+  - enterprise-linux-64-amazon-ami
+  - amazon2
+  - enterprise-amazon2
+  - enterprise-amazon2-arm64
+  - debian10
+  - enterprise-debian10-64
+  - debian92
+  - enterprise-debian92-64
+  - rhel70
+  - rhel76_compile_rhel70
+  - enterprise-rhel-70-64-bit
+  - enterprise-rhel-81-ppc64le
+  - enterprise-rhel-72-s390x
+  - ubi8
+  - rhel80
+  - rhel-82-arm64
+  - enterprise-rhel-80-64-bit
+  - enterprise-rhel-80-64-bit-coverage
+  - enterprise-rhel-80-64-bit-suggested
+  - enterprise-rhel-82-arm64
+  - suse12
+  - enterprise-suse12-64
+  - suse15
+  - enterprise-suse15-64
+  - ubuntu1804-debug-suggested
+  - enterprise-ubuntu-dynamic-1804-clang-tidy-required
+  - ubuntu1804
+  - ubuntu1804-arm64
+  - ubuntu2004-arm64
+  - ubuntu2004
+  - enterprise-ubuntu1804-64
+  - enterprise-ubuntu1804-arm64
+  - enterprise-ubuntu2004-arm64
+  - enterprise-ubuntu2004-64
+  - enterprise-windows
+  - enterprise-windows-required
+  - windows
+
+
+#######################################
+#            Functions                #
+#######################################
+
+functions:
+  "f_expansions_write": &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
+
+  "remove files":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/functions/files_remove.sh"
+
+  "configure evergreen api credentials": &configure_evergreen_api_credentials
+    command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/functions/evergreen_api_credentials_configure.sh"
+
+  "configure selected tests credentials": &configure_selected_tests_credentials
+    command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      silent: true
+      args:
+        - "src/evergreen/functions/selected_tests_credentials_configure.sh"
+      env:
+        project: ${project}
+        selected_tests_auth_user: ${selected_tests_auth_user}
+        selected_tests_auth_token: ${selected_tests_auth_token}
+
+  "git get project": &git_get_project
+    command: git.get_project
+    params:
+      directory: ${git_project_directory|src}
+      revisions: # for each module include revision as <module_name> : ${<module_name>_rev}
+        enterprise: ${enterprise_rev}
+        wtdevelop: ${wtdevelop_rev}
+
+  # Get get the mongo repo, no modules. Useful for inspecting the commit history with the
+  # `git` Python tool.
+  "git get project no modules":
+    - *f_expansions_write
+    - command: git.get_project
+      params:
+        directory: ${git_project_directory|src}
+
+  "add git tag": &add_git_tag
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/functions/add_git_tag.sh"
+      env:
+        future_git_tag: ${future_git_tag}
+        bv_future_git_tag: ${bv_future_git_tag}
+
+  "git get project and add git tag":
+    - *f_expansions_write
+    - *git_get_project
+    - *add_git_tag
+
+  "fetch artifacts": &fetch_artifacts
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/artifacts/${build_id}.tgz
+      bucket: mciuploads
+      extract_to: src
+
+  "fetch venv": &fetch_venv
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/venv/${build_id}.tgz
+      bucket: mciuploads
+      extract_to: "."
+
+  "adjust venv": &adjust_venv
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/functions/venv_adjust.sh"
+
+  "fetch packages": &fetch_packages
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/artifacts/${build_id}-packages.tgz
+      bucket: mciuploads
+      extract_to: src
+      build_variants: *package_variants
+
+  "fetch dist tarball": &fetch_dist_tarball
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/dist/mongo-${build_id}.${ext|tgz}
+      bucket: mciuploads
+      local_file: src/mongo-binaries.tgz
+
+  "fetch dist debugsymbols": &fetch_dist_debugsymbols
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/dist/mongo-${build_id}-debugsymbols.${ext|tgz}
+      bucket: mciuploads
+      local_file: src/mongo-debugsymbols.tgz
+      optional: true
+
+  "fetch binaries": &fetch_binaries
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${mongo_binaries}
+      bucket: mciuploads
+      local_file: src/mongo-binaries.tgz
+
+  "extract binaries": &extract_binaries
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/functions/binaries_extract.sh"
+
+  "check binary version": &check_binary_version
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/functions/binary_version_check.sh"
+
+  "fetch benchmarks": &fetch_benchmarks
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/benchmarks/${build_id}.tgz
+      bucket: mciuploads
+      extract_to: src
+
+  "fetch corpus": &fetch_corpus
+    command: s3.get
+    params:
+      aws_key: ${s3_access_key_id}
+      aws_secret: ${s3_secret_access_key}
+      bucket: fuzzer-artifacts
+      extract_to: src/corpora
+      remote_file: ${mongo_fuzzer_corpus}
+
+  "fetch legacy corpus": &fetch_legacy_corpus
+    command: s3.get
+    params:
+      aws_key: ${s3_access_key_id}
+      aws_secret: ${s3_secret_access_key}
+      bucket: fuzzer-artifacts
+      # Extract the legacy corpora to the merge directory to synthesize together until we burn in.
+      extract_to: src/corpora-merged
+      remote_file: ${project}/corpus/mongo-${build_variant}-latest.tgz
+
+  "archive new corpus": &archive_new_corpus
+    command: archive.targz_pack
+    params:
+      target: corpora.tgz
+      source_dir: src/corpora-merged
+      include:
+        - "**"
+
+  "upload new corpus": &upload_new_corpus
+    command: s3.put
+    params:
+      aws_key: ${s3_access_key_id}
+      aws_secret: ${s3_secret_access_key}
+      bucket: fuzzer-artifacts
+      content_type: ${content_type|application/gzip}
+      display_name: "Fuzzer Tests Corpus Tar Archive"
+      local_file: corpora.${ext|tgz}
+      optional: true
+      permissions: private
+      remote_file: ${mongo_fuzzer_corpus}
+      visibility: signed
+
+  "upload new corpus for mciuploads": &upload_new_corpus_mciuploads
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      bucket: mciuploads
+      content_type: ${content_type|application/gzip}
+      display_name: Input Corpora
+      local_file: corpora.${ext|tgz}
+      optional: true
+      permissions: private
+      remote_file: ${mongo_fuzzer_corpus_mciuploads}
+      visibility: signed
+
+  "get buildnumber": &get_buildnumber
+    command: keyval.inc
+    params:
+      key: "${build_variant}_master"
+      destination: "builder_num"
+
+  "run diskstats": &run_diskstats
+    command: subprocess.exec
+    params:
+      background: true
+      system_log: true
+      binary: bash
+      args:
+        - "./src/evergreen/functions/run_diskstats.sh"
+
+  "collect system resource info": &collect_system_resource_info
+    command: subprocess.exec
+    params:
+      background: true
+      system_log: true
+      binary: bash
+      args:
+        - "./src/evergreen/functions/system_resource_info_collect.sh"
+
+  "collect ulimit info": &collect_ulimit_info
+    command: subprocess.exec
+    params:
+      background: true
+      system_log: true
+      binary: bash
+      args:
+        - "./src/evergreen/functions/ulimit_info_collect.sh"
+
+  # Run a monitor process as a background, system task to periodically
+  # display how many threads interesting processes are using.
+  "monitor process threads": &monitor_process_threads
+    command: subprocess.exec
+    params:
+      background: true
+      system_log: true
+      binary: bash
+      args:
+        - "./src/evergreen/functions/process_threads_monitor.sh"
+
+  "set up credentials": &set_up_credentials
+    command: subprocess.exec
+    params:
+      binary: bash
+      silent: true
+      args:
+        - "./src/evergreen/functions/credentials_setup.sh"
+
+  "set up win mount script":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        silent: true
+        args:
+          - "./src/evergreen/functions/win_mount_script_setup.sh"
+
+  "set up notary client credentials":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        silent: true
+        args:
+          - "./src/evergreen/functions/notary_client_credentials_setup.sh"
+
+  "f_remote_credentials_setup_exec": &set_up_remote_credentials
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/functions/remote_credentials_setup.sh"
+      env:
+        private_key_remote_bash_var: ${private_key_remote}
+
+  "set up remote credentials":
+    - *f_expansions_write
+    - *set_up_remote_credentials
+
+  "upload debugsymbols": &upload_debugsymbols
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/mongo-debugsymbols.${ext|tgz}
+      remote_file: ${mongo_debugsymbols}
+      bucket: mciuploads
+      permissions: public-read
+      content_type: ${content_type|application/gzip}
+
+  "use WiredTiger develop":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/functions/wiredtiger_develop_use.sh"
+
+  "shared scons cache pruning":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: system
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/functions/shared_scons_cache_pruning.sh"
+
+  "umount shared scons directory":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/functions/shared_scons_directory_umount.sh"
+
+  "get all modified patch files":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/functions/modified_patch_files_get_all.sh"
+
+  # This function should only be called from patch-build-only tasks.
+  "get added and modified patch files":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/functions/added_and_modified_patch_files_get.sh"
+
+  "determine resmoke jobs": &determine_resmoke_jobs
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/functions/resmoke_jobs_determine.sh"
+
+  "update resmoke jobs expansions": &update_resmoke_jobs_expansions
+    command: expansions.update
+    params:
+      ignore_missing_file: true
+      file: src/resmoke_jobs_expansion.yml
+
+  "determine task timeout": &determine_task_timeout
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/functions/task_timeout_determine.sh"
+
+  "update task timeout expansions": &update_task_timeout_expansions
+    command: expansions.update
+    params:
+      ignore_missing_file: true
+      file: src/task_timeout_expansions.yml
+
+  "update task timeout": &update_task_timeout
+    command: timeout.update
+    params:
+      exec_timeout_secs: ${exec_timeout_secs}
+
+  ### Set expansion macros used in each task.
+  "set task expansion macros": &set_task_expansion_macros
+    command: expansions.update
+    params:
+      updates:
+      - key: mongo_binaries
+        value: ${project}/${build_variant}/${revision}/binaries/mongo-${build_id}.${ext|tgz}
+      - key: mongo_cryptd
+        value: ${project}/${build_variant}/${revision}/binaries/mongo-cryptd-${build_id}.${ext|tgz}
+      - key: mongo_cryptd_debugsymbols
+        value: ${project}/${build_variant}/${revision}/binaries/mongo-cryptd-debugsymbols-${build_id}.${ext|tgz}
+      - key: mh_archive
+        value: ${project}/${build_variant}/${revision}/binaries/mh-${build_id}.${ext|tgz}
+      - key: mh_debugsymbols
+        value: ${project}/${build_variant}/${revision}/debugsymbols/mh-debugsymbols-${build_id}.${ext|tgz}
+      - key: mongo_debugsymbols
+        value: ${project}/${build_variant}/${revision}/debugsymbols/debugsymbols-${build_id}.${ext|tgz}
+      - key: mongo_shell
+        value: ${project}/${build_variant}/${revision}/binaries/mongo-shell-${build_id}.${ext|tgz}
+      - key: mongo_shell_debugsymbols
+        value: ${project}/${build_variant}/${revision}/binaries/mongo-shell-debugsymbols-${build_id}.${ext|tgz}
+      - key: mongo_fuzzer_corpus_mciuploads
+        value: ${project}/${build_variant}/${revision}/libfuzzer-corpora/corpora-${build_id}.${ext|tgz}
+      - key: mongo_fuzzer_corpus
+        value: corpora-${project}-${build_variant}.${ext|tgz}
+      - key: skip_tests
+        value: skip_test-${build_id}
+
+  "set up venv": &set_up_venv
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/functions/venv_setup.sh"
+      env:
+        pip_dir: ${pip_dir}
+
+  "upload pip requirements": &upload_pip_requirements
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: pip-requirements.txt
+      remote_file: ${project}/${build_variant}/${revision}/pip-requirements-${task_id}-${execution}.txt
+      bucket: mciuploads
+      permissions: public-read
+      content_type: atext-plain
+      display_name: Pip Requirements
+
+  "send benchmark results":
+    - command: json.send
+      params:
+        name: perf
+        file: src/perf.json
+
+    - command: perf.send
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        prefix: ${task_id}_${execution}
+        file: src/cedar_report.json
+
+  "analyze benchmark results":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/functions/benchmark_results_analyze.sh"
+
+  "cleanup environment": &cleanup_environment
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/cleanup_environment.sh"
+
+  "kill processes": &kill_processes
+    command: subprocess.exec
+    params:
+      silent: true
+      binary: bash
+      args:
+        - "./src/evergreen/kill_processes.sh"
+
+  "do setup":
+  - *f_expansions_write
+  - *fetch_artifacts
+  - *kill_processes
+  - *cleanup_environment
+  - *fetch_venv
+  - *adjust_venv
+  - *fetch_binaries
+  - *extract_binaries
+  - *check_binary_version
+  - *get_buildnumber
+  - *f_expansions_write
+  - *set_up_credentials
+  - *run_diskstats
+  - *monitor_process_threads
+  - *collect_system_resource_info
+  - *collect_ulimit_info
+
+  "do non-compile setup":
+  - command: manifest.load
+  - *git_get_project
+  - *f_expansions_write
+  - *add_git_tag
+  - *kill_processes
+  - *cleanup_environment
+  - *set_up_venv
+  - *upload_pip_requirements
+  - *get_buildnumber
+  - *f_expansions_write
+  - *set_up_credentials
+
+  "do benchmark setup":
+  - command: manifest.load
+  - *git_get_project
+  - *f_expansions_write
+  - *add_git_tag
+  - *kill_processes
+  - *cleanup_environment
+  - *set_up_venv
+  - *upload_pip_requirements
+  - *get_buildnumber
+  - *f_expansions_write
+  - *set_up_credentials
+  - *fetch_benchmarks
+
+  "f_multiversion_setup_exec": &do_multiversion_setup
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/multiversion_setup.sh"
+
+  "do multiversion setup":
+    - *f_expansions_write
+    - *do_multiversion_setup
+
+  # Used by generator
+  "get compiled binaries":
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/compiled_binaries_get.sh"
+
+  "generate powercycle tasks":
+    - command: manifest.load
+    - *git_get_project
+    - *f_expansions_write
+    - *add_git_tag
+    - *kill_processes
+    - *cleanup_environment
+    - *set_up_venv
+    - *upload_pip_requirements
+
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_tasks_generate.sh"
+
+    - command: archive.targz_pack
+      params:
+        target: powercycle_tasks_config.tgz
+        source_dir: "./"
+        include:
+          - "powercycle_tasks.json"
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: powercycle_tasks_config.tgz
+        remote_file: ${project}/${build_variant}/${revision}/powercycle_tasks/${task_name}-${build_id}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Generated Task Config - Execution ${execution}
+
+    - command: generate.tasks
+      params:
+        files:
+          - powercycle_tasks.json
+
+  "run powercycle sentinel":
+    - command: manifest.load
+    - *git_get_project
+    - *f_expansions_write
+    - *add_git_tag
+    - *kill_processes
+    - *cleanup_environment
+    - *set_up_venv
+    - *upload_pip_requirements
+    - *configure_evergreen_api_credentials
+
+    - command: subprocess.exec
+      type: system
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_sentinel_run.sh"
+
+  "execute resmoke tests": &execute_resmoke_tests
+    command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/resmoke_tests_execute.sh"
+
+  "retrieve generated test configuration": &retrieve_generated_test_configuration
+    command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      bucket: mciuploads
+      # This expansion's name was shortened to reduce the overall size of
+      # the generated configuration file
+      # gtcl = gen_task_config_location
+      # gtcl expansion is a variable included in the call of the parent function.
+      remote_file: ${project}/${gtcl}
+      local_file: "generate_tasks_config.tgz"
+
+  "extract generated test configuration": &extract_generated_test_configuration
+    command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/extract_generated_test_configuration.sh"
+
+  "minimize jstestfuzz": &minimize_jstestfuzz
+    command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/jstestfuzz_minimize.sh"
+
+  "generate selected tests":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - *configure_selected_tests_credentials
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/selected_tests_generate.sh"
+    # this sets the gtcl expansion
+    - command: expansions.update
+      params:
+        ignore_missing_file: false
+        file: src/gtcl_update_expansions.yml
+    - *f_expansions_write
+    - command: archive.targz_pack
+      params:
+        target: generate_tasks_config.tgz
+        source_dir: src/generated_resmoke_config
+        include:
+          - "*"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: generate_tasks_config.tgz
+        remote_file: ${project}/${gtcl}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Generated Task Config - Execution ${execution}
+        optional: true
+    - command: generate.tasks
+      params:
+        optional: true
+        files:
+          - src/generated_resmoke_config/*.json
+
+  "generate build variant":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/generate_build_variant.sh"
+    # this sets the gtcl expansion
+    - command: expansions.update
+      params:
+        ignore_missing_file: false
+        file: src/gtcl_update_expansions.yml
+    - *f_expansions_write
+    - command: archive.targz_pack
+      params:
+        target: generate_tasks_config.tgz
+        source_dir: src/generated_resmoke_config
+        include:
+          - "*"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: generate_tasks_config.tgz
+        remote_file: ${project}/${gtcl}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Generated Task Config - Execution ${execution}
+        optional: true
+    - command: generate.tasks
+      params:
+        optional: true
+        files:
+          - src/generated_resmoke_config/*.json
+
+  "generate burn in tags":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/burn_in_tests_generate.sh"
+    - command: archive.targz_pack
+      params:
+        target: burn_in_tags_gen.tgz
+        source_dir: src/generated_burn_in_tags_config
+        include:
+          - "*"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: burn_in_tags_gen.tgz
+        remote_file: ${project}/${build_variant}/${revision}/burn_in_tags_gen/burn_in_tags_gen-${build_id}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Burn_in_tags Task Config - Execution ${execution}
+    - command: generate.tasks
+      params:
+        files:
+          - src/generated_burn_in_tags_config/burn_in_tags_gen.json
+
+  "generate resmoke tasks":
+    - *fetch_artifacts
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - *fetch_venv
+    - *adjust_venv
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/gen_tasks_activate.sh"
+
+  # Used by generator
+  "validate resmoke tests runtime":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/resmoke_tests_runtime_validate.sh"
+
+  # Used by generator
+  "run generated tests":
+  - *f_expansions_write
+  - *retrieve_generated_test_configuration
+  - *extract_generated_test_configuration
+  - *f_expansions_write
+  - command: expansions.update
+    params:
+      updates:
+      - key: aws_key_remote
+        value: ${mongodatafiles_aws_key}
+      - key: aws_profile_remote
+        value: mongodata_aws
+      - key: aws_secret_remote
+        value: ${mongodatafiles_aws_secret}
+  - *f_expansions_write
+  - *set_up_remote_credentials
+  - *f_expansions_write
+  - *determine_resmoke_jobs
+  - *update_resmoke_jobs_expansions
+  - *f_expansions_write
+  - *configure_evergreen_api_credentials
+  - *determine_task_timeout
+  - *update_task_timeout_expansions
+  - *f_expansions_write
+  - command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/multiversion_exclude_tags_generate.sh"
+  - *execute_resmoke_tests
+  - *minimize_jstestfuzz
+    # The existence of the "run_tests_infrastructure_failure" file indicates this failure isn't
+    # directly actionable. We use type=setup rather than type=system or type=test for this command
+    # because we don't intend for any human to look at this failure.
+  - command: subprocess.exec
+    type: setup
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/check_run_tests_infrastructure_failure.sh"
+  - command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/check_resmoke_failure.sh"
+
+  "run tests":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - *determine_task_timeout
+    - *update_task_timeout_expansions
+    - *f_expansions_write
+    - *update_task_timeout
+    - *f_expansions_write
+    - command: expansions.update
+      params:
+        env:
+          CEDAR_USER: ${cedar_user}
+          CEDAR_API_KEY: ${cedar_api_key}
+        updates:
+        - key: aws_key_remote
+          value: ${mongodatafiles_aws_key}
+        - key: aws_profile_remote
+          value: mongodata_aws
+        - key: aws_secret_remote
+          value: ${mongodatafiles_aws_secret}
+    - *f_expansions_write
+    - *set_up_remote_credentials
+    - *f_expansions_write
+    - *determine_resmoke_jobs
+    - *update_resmoke_jobs_expansions
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/multiversion_exclude_tags_generate.sh"
+    - *execute_resmoke_tests
+      # The existence of the "run_tests_infrastructure_failure" file indicates this failure isn't
+      # directly actionable. We use type=setup rather than type=system or type=test for this command
+      # because we don't intend for any human to look at this failure.
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/check_run_tests_infrastructure_failure.sh"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/check_resmoke_failure.sh"
+
+  "scons lint":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/scons_lint.sh"
+
+  "scons compile":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/scons_compile.sh"
+
+  "generate compile expansions":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/functions/compile_expansions_generate.sh"
+
+  "apply compile expansions":
+    - command: expansions.update
+      params:
+        file: src/compile_expansions.yml
+    - *f_expansions_write
+
+  "do jepsen setup":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/do_jepsen_setup/build_libfaketime.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/do_jepsen_setup/install_jepsen.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/do_jepsen_setup/nodes.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/do_jepsen_setup/move_binaries.sh"
+
+  "do jepsen docker setup":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: system
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_docker/setup.sh"
+  "run jepsen docker test":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_docker/docker-up.sh"
+    - command: archive.targz_pack
+      params:
+        target: jepsen-docker-log.tgz
+        source_dir: jepsen/docker
+        include:
+          - "docker.log"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: jepsen-docker-log.tgz
+        remote_file: ${project}/${build_variant}/${revision}/jstestfuzz/jepsen-docker-log-${task_id}-${execution}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/gzip
+        display_name: Jepsen Docker Build Log - Execution ${execution}
+
+    - command: subprocess.exec
+      type: test
+      timeout_secs: 2700 # Timeout test if there is no output for more than 45 minutes.
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_docker/list-append.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_test_fail.sh"
+
+  "cleanup jepsen docker test":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: system
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_docker/cleanup.sh"
+
+  "run jepsen test":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      timeout_secs: 2700 # Timeout test if there is no output for more than 45 minutes.
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_test_run.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jepsen_test_fail.sh"
+
+  "load aws test credentials":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        silent: true
+        args:
+          - "./src/evergreen/functions/aws_test_credentials_load.sh"
+
+  "setup jstestfuzz":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jstestfuzz_setup.sh"
+
+  "lint fuzzer sanity patch":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/lint_fuzzer_sanity_patch.sh"
+
+  "lint fuzzer sanity all":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/lint_fuzzer_sanity_all.sh"
+
+  # Used by generator
+  "run jstestfuzz":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/run_jstestfuzz/clone_repos.sh"
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/jstestfuzz_run.sh"
+    - command: archive.targz_pack
+      params:
+        target: "jstests.tgz"
+        source_dir: "src/jstestfuzz"
+        include:
+          - "out/*.js"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: jstests.tgz
+        remote_file: ${project}/${build_variant}/${revision}/jstestfuzz/${task_id}-${execution}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/gzip
+        display_name: Generated Tests - Execution ${execution}
+
+  "upload npm logs":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/move_npm_logs.sh"
+    - command: archive.targz_pack
+      params:
+        target: "npm-logs.tgz"
+        source_dir: "${workdir}/"
+        include:
+          - "_logs/*"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: npm-logs.tgz
+        remote_file: ${project}/${build_variant}/${revision}/jstestfuzz/${task_id}-${execution}-npm-logs.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/gzip
+        display_name: npm logs - Execution ${execution}
+
+  "upload jstestfuzz minimized output":
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/minimizer-outputs.json
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/minimizer-outputs-${task_id}-${execution}.json
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/json
+        display_name: Minimizer Outputs - Execution ${execution}
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/jstestfuzz/out/minimizer-outputs-minimizedtest.js
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/minimizer-outputs-minimizedtest-${task_id}-${execution}.js
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: text/javascript
+        display_name: Minimized jstestfuzz Test - Execution ${execution}
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/wiki_page_minimized_agg_query_fuzzer.sh"
+    - command: attach.artifacts
+      params:
+        files:
+          - wiki_page_running_minimized_test_location.json
+
+  "run idl tests":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/idl_tests_run.sh"
+
+  "run powercycle test":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_run_test.sh"
+
+    - command: expansions.update
+      params:
+        ignore_missing_file: true
+        file: src/powercycle_exit.yml
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_ssh_failure_exit.sh"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_exit.sh"
+
+  "run packager.py":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/packager.py_run.sh"
+
+  "do snmp setup":
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/do_snmp_setup.sh"
+
+  "do watchdog setup":
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/do_watchdog_setup.sh"
+
+  "run kitchen":
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/kitchen_run.sh"
+
+  "set up EC2 instance": &set_up_ec2_instance
+
+    - command: host.create
+      params:
+        provider: ec2
+        distro: ${distro_id}
+        timeout_teardown_secs: 604800 # 7 days
+        security_group_ids:
+        - sg-097bff6dd0d1d31d0
+
+    - command: host.list
+      params:
+        wait: true
+        timeout_seconds: 3000
+        num_hosts: 1
+        path: src/hosts.yml
+
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_check_host.sh"
+
+    - command: expansions.update
+      params:
+        file: src/powercycle_ip_address.yml
+
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/powercycle_setup_host.sh"
+
+  "run selinux tests":
+    - command: host.create
+      params:
+        provider: ec2
+        distro: ${distro}
+        timeout_teardown_secs: 86400 # 1 day
+    - command: host.list
+      params:
+        wait: true
+        timeout_seconds: 900 # 15 min
+        num_hosts: 1
+        path: src/hosts.yml
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        redirect_standard_error_to_output: true
+        args:
+          - "./src/evergreen/selinux_run_test.sh"
+        env:
+          test_list: ${test_list}
+          user: ec2-user
+
+
+  ### Process & archive remote EC2 artifacts ###
+  "save powercycle artifacts": &save_powercycle_artifacts
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/powercycle_save_artifacts.sh"
+
+  "archive remote EC2 artifacts": &archive_remote_ec2_artifacts
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/ec2_artifacts.tgz
+      remote_file: ${project}/${build_variant}/${revision}/remote_ec2/remote_ec2_artifacts-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: ${content_type|application/gzip}
+      display_name: Remote EC2 Artifacts - Execution ${execution}
+      optional: true
+
+  "archive remote EC2 monitor files": &archive_remote_ec2_monitor_files
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/ec2_monitor_files.tgz
+      remote_file: ${project}/${build_variant}/${revision}/remote_ec2/remote_ec2_monitor-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: ${content_type|application/gzip}
+      display_name: Remote EC2 Monitor - Execution ${execution}
+      optional: true
+
+  "save ec2 task artifacts":
+    - *f_expansions_write
+    - *save_powercycle_artifacts
+    - *archive_remote_ec2_artifacts
+    - *archive_remote_ec2_monitor_files
+
+  ### Process & archive local client logs ###
+  "tar local client logs": &tar_local_client_logs
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/local_client_logs_tar.sh"
+
+  "archive local client logs": &archive_local_client_logs
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/client-logs.tgz
+      remote_file: ${project}/${build_variant}/${revision}/client_logs/mongo-client-logs-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: ${content_type|application/gzip}
+      display_name: Client logs - Execution ${execution}
+      optional: true
+
+  "save local client logs":
+    - *f_expansions_write
+    - *tar_local_client_logs
+    - *archive_local_client_logs
+
+  ### Cleanup after the watchdog FUSE testing ###
+  "cleanup FUSE watchdog":
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/functions/fuse_watchdog_cleanup.sh"
+
+  ### Process & archive Code Coverage artifacts ###
+  "process code coverage data": &process_code_coverage_data
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/functions/code_coverage_data_process.sh"
+
+  "tar code coverage data": &tar_code_coverage_data
+    command: archive.targz_pack
+    params:
+      target: "src/gcov-intermediate-files.tgz"
+      source_dir: "src"
+      include:
+        - "*.gcda.gcov"
+
+  "archive code coverage data": &archive_code_coverage_data
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: "src/gcov-intermediate-files.tgz"
+      remote_file: ${project}/${build_variant}/${revision}/gcov/gcov-intermediate-files-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: gcov intermediate files - Execution ${execution}
+      optional: true
+
+  "save code coverage data":
+    - *f_expansions_write
+    - *process_code_coverage_data
+    - *tar_code_coverage_data
+    - *archive_code_coverage_data
+
+  "tar jepsen logs": &tar_jepsen_logs
+    command: archive.targz_pack
+    params:
+      target: "src/jepsen-mongod-logs.tgz"
+      source_dir: "${workdir}/src/jepsen-workdir"
+      include:
+        - "./**.log"
+
+  "archive jepsen logs": &archive_jepsen_logs
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/jepsen-mongod-logs.tgz
+      remote_file: ${project}/${build_variant}/${revision}/jepsen/jepsen-mongod-logs-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Jepsen mongod Logs - ${execution}
+      optional: true
+
+  "tar jepsen results": &tar_jepsen_results
+    command: archive.targz_pack
+    params:
+      target: "src/jepsen-results.tgz"
+      source_dir: "src/jepsen-mongodb/store"
+      include:
+        - "./**"
+
+  "archive jepsen results": &archive_jepsen_results
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/jepsen-results.tgz
+      remote_file: ${project}/${build_variant}/${revision}/jepsen/jepsen-results-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Jepsen Test Results - ${execution}
+      optional: true
+
+  "save jepsen artifacts":
+    - *tar_jepsen_logs
+    - *archive_jepsen_logs
+    - *tar_jepsen_results
+    - *archive_jepsen_results
+
+  ### Process & archive mongo coredumps ###
+  "gather mongo coredumps": &gather_mongo_coredumps
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/gather_mongo_coredumps.sh"
+
+  "tar mongo coredumps": &tar_mongo_coredumps
+    command: archive.targz_pack
+    params:
+      target: "mongo-coredumps.tgz"
+      source_dir: "src"
+      include:
+        - "./**.core"
+        - "./**.mdmp" # Windows: minidumps
+
+  "archive mongo coredumps": &archive_mongo_coredumps
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: mongo-coredumps.tgz
+      remote_file: ${project}/${build_variant}/${revision}/coredumps/mongo-coredumps-${build_id}-${task_name}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Core Dumps - Execution ${execution}
+      optional: true
+
+  "save mongo coredumps":
+  - *f_expansions_write
+  - *gather_mongo_coredumps
+  - *tar_mongo_coredumps
+  - *archive_mongo_coredumps
+
+  ### Process & archive failed unittest artifacts ###
+  "gather failed unittests": &gather_failed_unittests
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/failed_unittests_gather.sh"
+
+  "tar failed unittests": &tar_failed_unittests
+    command: archive.targz_pack
+    params:
+      target: "mongo-unittests.tgz"
+      source_dir: "src/dist-unittests"
+      include:
+        - "**"
+
+  "archive failed unittests": &archive_failed_unittests
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: mongo-unittests.tgz
+      remote_file: ${project}/${build_variant}/${revision}/unittests/mongo-unittests-${build_id}-${task_name}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Unit tests - Execution ${execution}
+      optional: true
+
+  "save failed unittests":
+  - *f_expansions_write
+  - *gather_failed_unittests
+  - *tar_failed_unittests
+  - *archive_failed_unittests
+
+  "archive dbtest": &archive_dbtest
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: dbtest-binary.tgz
+      remote_file: ${project}/${build_variant}/${revision}/dbtest/dbtest-${build_id}-${task_name}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/tar
+      display_name: dbtest binary - Execution ${execution}
+      optional: true
+
+  "archive dbtest debugsymbols": &archive_dbtest_debug
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: dbtest-debugsymbols.tgz
+      remote_file: ${project}/${build_variant}/${revision}/dbtest/dbtest-${build_id}-${task_name}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/tar
+      display_name: dbtest debugsymbols
+      optional: true
+
+  "save unstripped dbtest":
+  - *archive_dbtest
+  - *archive_dbtest_debug
+
+  ### Process & archive artifacts from hung processes ###
+  "run hang analyzer":
+    - *f_expansions_write
+    - *configure_evergreen_api_credentials
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/hang_analyzer.sh"
+
+  "wait for resmoke to shutdown":
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/wait_for_resmoke_to_shutdown.sh"
+
+  "tar hang analyzer debugger files": &tar_hang_analyzer_debugger_files
+    command: archive.targz_pack
+    params:
+      target: "src/mongo-hanganalyzer.tgz"
+      source_dir: "src"
+      include:
+        - "./debugger*.*"
+
+  "archive hang analyzer debugger files": &archive_hang_analyzer_debugger_files
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/mongo-hanganalyzer.tgz
+      remote_file: ${project}/${build_variant}/${revision}/hanganalyzer/mongo-hanganalyzer-${build_id}-${task_name}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Hang Analyzer Output - Execution ${execution}
+      optional: true
+
+  "save hang analyzer debugger files":
+  - *tar_hang_analyzer_debugger_files
+  - *archive_hang_analyzer_debugger_files
+
+  ### Process & archive disk statistic artifacts ###
+  "tar disk statistics": &tar_disk_statistics
+    command: archive.targz_pack
+    params:
+      target: "diskstats.tgz"
+      source_dir: "./"
+      include:
+        - "./mongo-diskstats*"
+        - "./mongo-diskstats*.csv"
+
+  "archive disk statistics": &archive_disk_statistics
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: diskstats.tgz
+      remote_file: ${project}/${build_variant}/${revision}/diskstats/mongo-diskstats-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Disk Stats - Execution ${execution}
+      optional: true
+
+  "save disk statistics":
+  - *tar_disk_statistics
+  - *archive_disk_statistics
+
+  "save libfuzzertest corpora":
+  - *archive_new_corpus
+  - *upload_new_corpus
+  - *upload_new_corpus_mciuploads
+
+  ### Process & archive system resource artifacts ###
+  "tar system resource information": &tar_system_resource_information
+    command: archive.targz_pack
+    params:
+      target: "system-resource-info.tgz"
+      source_dir: src
+      include:
+        - "./system_resource_info*"
+
+  "archive system resource information": &archive_system_resource_information
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: system-resource-info.tgz
+      remote_file: ${project}/${build_variant}/${revision}/systemresourceinfo/mongo-system-resource-info-${task_id}-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: System Resource Info - Execution ${execution}
+      optional: true
+
+  "save system resource information":
+  - *tar_system_resource_information
+  - *archive_system_resource_information
+
+  "tar UndoDB recordings": &tar_undodb_recordings
+    command: archive.targz_pack
+    params:
+      target: undodb-recordings.tgz
+      source_dir: src
+      include:
+        - "./*.undo.tokeep"
+        - "./*.undo"
+
+  "archive UndoDB recordings": &archive_undodb_recordings
+    command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: undodb-recordings.tgz
+      remote_file: ${project}/${build_variant}/${revision}/undo/undodb-recordings-${task_id}-execution-${execution}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: UndoDB Recordings - Execution ${execution}
+      optional: true
+
+  "save UndoDB recordings":
+  - *tar_undodb_recordings
+  - *archive_undodb_recordings
+
+  ### Attach report & artifacts ###
+  "attach scons logs":
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/build/scons/config.log
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/scons-config.log.${build_id}-${task_name}-${execution}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/plain
+        display_name: SCons configure log
+
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/scons_cache.log
+        content_type: text/plain
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/scons-cache.log.${build_id}-${task_name}.${execution}
+        bucket: mciuploads
+        permissions: public-read
+        display_name: SCons cache debug log
+
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        continue_on_err: true
+        binary: bash
+        args:
+          - "./src/evergreen/scons_splunk.sh"
+
+  "attach report":
+    command: attach.results
+    params:
+      file_location: ${report_file|src/report.json}
+
+  "attach artifacts":
+    command: attach.artifacts
+    params:
+      optional: true
+      ignore_artifacts_for_spawn: false
+      files:
+        - ${archive_file|src/archive.json}
+
+  "attach wiki page":
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/wiki_page.sh"
+    - command: attach.artifacts
+      params:
+        files:
+          - wiki_page_location.json
+
+  "attach local resmoke invocation":
+    command: s3.put
+    params:
+      optional: true
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/local-resmoke-invocation.txt
+      remote_file: ${project}/${build_variant}/${revision}/local-resmoke-invocation-${task_id}-${execution}.txt
+      bucket: mciuploads
+      permissions: public-read
+      content_type: atext-plain
+      display_name: Resmoke.py Invocation for Local Usage
+
+
+# Pre task steps
+pre:
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+
+# Post task steps
+post:
+  - func: "f_expansions_write"
+  - func: "upload npm logs"
+  - func: "attach local resmoke invocation"
+  - func: "attach report"
+  - func: "attach artifacts"
+  - func: "save ec2 task artifacts"
+  - func: "attach wiki page"
+  - func: "upload jstestfuzz minimized output"
+  - func: "kill processes"
+  - func: "save local client logs"
+  - func: "save code coverage data"
+  - func: "save jepsen artifacts"
+  - func: "save mongo coredumps"
+  - func: "save failed unittests"
+  - func: "save hang analyzer debugger files"
+  - func: "save disk statistics"
+  - func: "save system resource information"
+  - func: "save UndoDB recordings"
+  - func: "umount shared scons directory"
+  - func: "cleanup FUSE watchdog"
+  - func: "cleanup environment"
+  - func: "cleanup jepsen docker test"
+
+# Timeout steps
+timeout:
+  - func: "f_expansions_write"
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
+
+
+#######################################
+#               Tasks                 #
+#######################################
+
+tasks:
+
+## compile - build all scons targets except unittests ##
+- name: compile_dist_test
+  tags: []
+  depends_on: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: >-
+          install-dist-test
+          ${additional_compile_targets|}
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+- name: determine_patch_tests
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/gen_patch_test_tags.sh"
+
+- name: archive_dist_test
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: >-
+          archive-dist-test
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-binaries.${ext|tgz}
+        remote_file: ${mongo_binaries}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/gzip
+        display_name: Binaries
+
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/gen_feature_flags.sh"
+
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/get_bin_and_fcv_versions.sh"
+
+    - command: archive.targz_pack
+      params:
+        target: "artifacts.tgz"
+        source_dir: "src"
+        include:
+          - ".resmoke_mongo_version.yml"
+          - ".resmoke_mongo_release_values.yml"
+          - "patch_test_tags.tgz"
+          - "./build/**.gcno"
+          - "./etc/*san.suppressions"
+          - "./etc/backports_required_for_multiversion_tests.yml"
+          - "./etc/evergreen_timeouts.yml"
+          - "./etc/expansions.default.yml"
+          - "./etc/evergreen.yml"
+          - "./etc/pip/**"
+          - "./etc/repo_config.yaml"
+          - "./etc/scons/**"
+          - "buildscripts/**"
+          - "compile_expansions.yml"
+          - "all_feature_flags.txt"  # Must correspond to the definition in buildscripts/idl/lib.py.
+          - "jstests/**"
+          - "patch_files.txt"
+          - "evergreen/**"
+          - "src/mongo/client/sdam/json_tests/sdam_tests/**"
+          - "src/mongo/client/sdam/json_tests/server_selection_tests/**"
+          - "src/mongo/db/modules/enterprise/docs/**"
+          - "src/mongo/db/modules/enterprise/jstests/**"
+          - "src/mongo/db/modules/subscription/jstests/**"
+          - "src/mongo/util/options_parser/test_config_files/**"
+          - "src/third_party/JSON-Schema-Test-Suite/tests/draft4/**"
+          - "src/third_party/mock_ocsp_responder/**"
+          - "src/third_party/schemastore.org/**"
+        exclude_files:
+          - "*_test.pdb"
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: artifacts.tgz
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/${build_id}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/tar
+        display_name: Artifacts
+
+    - command: archive.targz_pack
+      params:
+        target: "venv.tgz"
+        source_dir: "./"
+        include:
+          - "./venv/**"
+          - "./venv_readme.txt"
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: venv.tgz
+        remote_file: ${project}/${build_variant}/${revision}/venv/${build_id}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/tar
+        display_name: Python venv (see included venv_readme.txt)
+
+- name: archive_dist_test_debug
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: >-
+          archive-dist-test-debug
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+    - func: "upload debugsymbols"
+
+- name: compile_ninja
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        generating_for_ninja: true
+        separate_debug: off
+        task_install_action:
+          default
+        task_compile_flags: >-
+          --ninja
+        targets:
+          generate-ninja
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/ninja_compile.sh"
+
+- name: compile_ninja_next
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        generating_for_ninja: true
+        separate_debug: off
+        task_install_action:
+          default
+        task_compile_flags: >-
+          --build-tools=next
+          --ninja
+        targets:
+          generate-ninja
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/ninja_compile.sh"
+
+- name: compile_build_tools_next
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        task_compile_flags: >-
+          --build-tools=next
+        targets:
+          install-core
+
+- name: libdeps_graph_linting
+  tags: []
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/libdeps_setup.sh"
+
+    - func: "scons compile"
+      vars:
+        task_compile_flags: >-
+          --link-model=dynamic
+          --build-tools=next
+        targets:
+          generate-libdeps-graph
+
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/libdeps_run.sh"
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/results.txt
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/libdeps-results.txt.${build_id}-${task_name}.${execution}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/plain
+        display_name: Libdeps Linter Results
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/libdeps.graphml.gz
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/libdeps.graphml.${build_id}-${task_name}.${execution}.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Libdeps Graph Data
+
+## compile_all - build all scons targets ##
+- name: compile_all
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-all-meta
+        compiling_for_test: true
+
+## clang_tidy - run clang_tidy
+- name: clang_tidy
+  tags: []
+  exec_timeout_secs: 3600 # 1 hour timeout for the task overall
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: generated-sources compiledb
+        compiling_for_test: true
+    - command: subprocess.exec
+      type: test
+      timeout_secs: 3600 # 1 hour timeout for no output
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/run_clang_tidy.sh"
+
+## compile_unittests ##
+- &compile_unittests
+  name: compile_unittests
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-unittests install-unittests-debug
+        compiling_for_test: true
+
+## A copy of the compile_unittests task for the recorded unittest taskgroup ##
+- <<: *compile_unittests
+  name: compile_unittests_for_recorded_unittest
+
+## run_unittests ##
+- name: run_unittests
+  tags: []
+  depends_on:
+    - name: compile_unittests
+  commands:
+    - *f_expansions_write
+    - func: "run diskstats"
+    - func: "f_expansions_write"
+    - func: "monitor process threads"
+    - func: "collect system resource info"
+    - func: "run tests"
+      vars:
+        suite: unittests
+
+## run_unittests with UndoDB live-record ##
+#- name: run_unittests_with_recording
+#  depends_on:
+#    - name: compile_unittests_for_recorded_unittest
+#  commands:
+#    - *f_expansions_write
+#    - func: "run diskstats"
+#    - func: "f_expansions_write"
+#    - func: "monitor process threads"
+#    - func: "collect system resource info"
+#    - command: subprocess.exec
+#      params:
+#        binary: bash
+#        args:
+#          - "./src/evergreen/undo_wiki_page.sh"
+#    - command: attach.artifacts
+#      params:
+#        files:
+#          - undo_wiki_page_location.json
+#    - func: "run tests"
+#      vars:
+#        suite: unittests
+#        record_with: --recordWith /opt/undodb5/bin/live-record
+#        # Start fewer jobs since there's a constant amount of overhead of starting
+#        # live-record for each job.
+#        resmoke_jobs_factor: 0.3
+
+
+##compile_and_archive_libfuzzertests - build libfuzzertests ##
+- name: compile_and_archive_libfuzzertests
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: archive-fuzzertests
+        compiling_for_test: true
+    # Store the fuzzer executable, which we use to generate and run fuzzer inputs.
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/fuzzertests-runtime.tgz"
+        remote_file: "${project}/libfuzzer-tests/${build_variant}/${revision}/libfuzzer-tests.tgz"
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/tar
+        display_name: "LibFuzzer Tests"
+
+## fetch_and_run_libfuzzertests - get input corpora from s3 and run libfuzzertests ##
+- name: fetch_and_run_libfuzzertests
+  tags: []
+  commands:
+    - func: "fetch corpus"
+    - func: "fetch legacy corpus"
+    - func: "run tests"
+      vars:
+        suite: libfuzzer
+
+- name: server_discovery_and_monitoring_json_test
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-sdam-json-test
+        compiling_for_test: true
+    - func: "run tests"
+      vars:
+        suite: sdam_json_test
+
+- name: server_selection_json_test
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-server-selection-json-test
+        compiling_for_test: true
+    - func: "run tests"
+
+## compile_dbtest ##
+- name: compile_dbtest
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-dbtest install-dbtest-debug
+        compiling_for_test: true
+
+## run_dbtest ##
+- name: run_dbtest
+  tags: []
+  depends_on:
+    - name: compile_dbtest
+  commands:
+    - *f_expansions_write
+    - func: "run diskstats"
+    - func: "f_expansions_write"
+    - func: "monitor process threads"
+    - func: "collect system resource info"
+    - func: "run tests"
+      vars:
+        suite: dbtest
+        install_dir: build/install/bin
+
+- name: archive_dbtest
+  tags: []
+  depends_on:
+    - name: compile_dbtest
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: archive-dbtest archive-dbtest-debug
+        compiling_for_test: true
+
+- name: compile_visibility_test
+  tags: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: archive-visibility-test-meta
+        task_compile_flags: >-
+          --ssl
+          --dbg=on
+          --opt=on
+          --link-model=dynamic
+          --visibility-support=on
+
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/visibility-test-meta.${ext|tgz}
+        remote_file: ${project}/${build_variant}/${revision}/visibility-test-meta-${build_id}-${task_name}-${execution}.${ext|tgz}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Binaries
+
+## embedded_sdk_build_and_test_* - build the embedded-dev and embedded-test targets only ##
+
+- name: embedded_sdk_build_cdriver
+  tags: []
+  commands:
+    - func: f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/embedded_sdk_build_cdriver.sh"
+
+- name: embedded_sdk_install_dev
+  tags: []
+  depends_on:
+    - name: embedded_sdk_build_cdriver
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-embedded-dev
+        task_compile_flags: &embedded_sdk_compile_flags >-
+          --allocator=system
+          --dbg=off
+          --enable-free-mon=off
+          --enable-http-client=off
+          --js-engine=none
+          --opt=size
+          --ssl=off
+          --use-system-mongo-c=on
+          DESTDIR='$BUILD_ROOT/mongo-embedded-sdk-$MONGO_VERSION'
+          CPPPATH='$BUILD_ROOT/mongo-embedded-sdk-$MONGO_VERSION/include/libbson-1.0 $BUILD_ROOT/mongo-embedded-sdk-$MONGO_VERSION/include/libmongoc-1.0'
+        task_compile_flags_extra: >-
+          --link-model=dynamic-sdk
+
+- name: embedded_sdk_s3_put
+  tags: []
+  depends_on:
+    - name: embedded_sdk_install_dev
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/embedded_sdk_s3_tar.sh"
+
+    # Upload it so we can download from EVG.
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/build/embedded-sdk.tgz"
+        remote_file: ${project}/embedded-sdk/${build_variant}/${revision}/mongo-embedded-sdk-${version}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: "Embedded SDK Tar Archive"
+
+- name: embedded_sdk_install_tests
+  tags: []
+  depends_on:
+    - name: embedded_sdk_install_dev
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-embedded-test
+        compiling_for_test: true
+        task_compile_flags: *embedded_sdk_compile_flags
+        task_compile_flags_extra: >-
+          --link-model=dynamic
+        # Unlike static builds, dynamic builds have no need to
+        # constrain the number of link jobs. Unfortunately, --jlink=1
+        # means one link job, not 100%. So this is a bit gross but set
+        # it to .99.
+        num_scons_link_jobs_available: 0.99
+
+- name: embedded_sdk_tests_s3_put
+  tags: []
+  depends_on:
+    - name: embedded_sdk_install_tests
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/embedded_sdk_tests_s3_tar.sh"
+
+    # Upload it so we can download from EVG.
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/build/embedded-sdk-tests.tgz"
+        remote_file: ${project}/embedded-sdk-test/${build_variant}/${revision}/mongo-embedded-sdk-test-${version}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: "Embedded SDK Tests Tar Archive"
+
+- name: embedded_sdk_run_tests
+  tags: []
+  depends_on:
+    - name: embedded_sdk_install_tests
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/embedded_sdk_run_tests.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/embedded_sdk_run_tests_post.sh"
+
+- name: embedded_sdk_s3_put_latest
+  tags: []
+  depends_on:
+    - name: embedded_sdk_run_tests
+  commands:
+    # A second put, this time to -latest, to give devs a reasonable
+    # way to get the most recent build.
+    - command: s3.put
+      params:
+        visibility: none
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/build/embedded-sdk.tgz"
+        remote_file: ${project}/embedded-sdk/mongo-${build_variant}-latest.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+
+- name: embedded_sdk_tests_s3_put_latest
+  tags: []
+  depends_on:
+    - name: embedded_sdk_run_tests
+  commands:
+    # A second put, this time to -latest, to give devs a reasonable
+    # way to get the most recent build.
+    - command: s3.put
+      params:
+        visibility: none
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/build/embedded-sdk-tests.tgz"
+        remote_file: ${project}/embedded-sdk-test/mongo-${build_variant}-latest.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+
+- name: stitch_support_create_lib
+  tags: []
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: install-stitch-support install-stitch-support-debug install-stitch-support-dev
+        task_compile_flags: >-
+          --link-model=dynamic-sdk
+          --enable-free-mon=off
+          --ssl=off
+          --enable-http-client=off
+          --modules=
+          DESTDIR='$BUILD_ROOT/stitch-support-lib-$MONGO_VERSION'
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/stitch_support_create_lib_tar.sh"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/build/stitch-support.tgz"
+        remote_file: "${project}/stitch-support/${build_variant}/${revision}/stitch-support-${version}.tgz"
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: "Stitch Support Library"
+
+- name: stitch_support_install_tests
+  tags: []
+  depends_on:
+    - name: stitch_support_create_lib
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: install-stitch-support-test
+        compiling_for_test: true
+        task_compile_flags: >-
+          --enable-free-mon=off
+          --ssl=off
+          --enable-http-client=off
+          --modules=
+          DESTDIR='$BUILD_ROOT/stitch-support-lib-$MONGO_VERSION'
+
+- name: stitch_support_run_tests
+  tags: []
+  depends_on:
+    - name: stitch_support_install_tests
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/stitch_support_run_tests.sh"
+
+- name: csfle_create_lib
+  tags: []
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: archive-mongo-csfle-dev
+        task_compile_flags: >-
+          --allocator=system
+          --enable-free-mon=off
+          --enterprise-features=fle
+          --js-engine=none
+          --link-model=dynamic-sdk
+          ${csfle_task_compile_flags}
+          DESTDIR='$BUILD_ROOT/csfle-lib-$MONGO_VERSION'
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/csfle_run_tests.sh"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/mongo-csfle-dev.${ext|tgz}"
+        remote_file: "${project}/mongo_csfle/${build_variant}/${revision}/mongo_csfle_v1-${version}.${ext|tgz}"
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/tar}
+        display_name: "Mongo CSFLE Library"
+
+- name: csfle_create_debug_lib
+  tags: []
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: archive-mongo-csfle-dev archive-mongo-csfle-debug
+        task_compile_flags: >-
+          --dbg=on
+          --opt=off
+          --allocator=system
+          --enable-free-mon=off
+          --enterprise-features=fle
+          --js-engine=none
+          --link-model=dynamic-sdk
+          DESTDIR='$BUILD_ROOT/csfle-lib-$MONGO_VERSION'
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/mongo-csfle-dev.${ext|tgz}"
+        remote_file: "${project}/mongo_csfle/${build_variant}/${revision}/mongo_csfle_v1_dev-${version}.${ext|tgz}"
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/tar}
+        display_name: "Mongo CSFLE Library dev"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/mongo-csfle-debug.${ext|tgz}"
+        remote_file: "${project}/mongo_csfle/${build_variant}/${revision}/mongo_csfle_v1_debug-${version}.${ext|tgz}"
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/tar}
+        display_name: "Mongo CSFLE Library debug"
+
+- name: csfle_install_tests
+  tags: []
+  depends_on:
+    - name: csfle_create_debug_lib
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: archive-mongo-csfle-shlib-test
+        compiling_for_test: true
+        task_install_action:
+          default
+        task_compile_flags: >-
+          --allocator=system
+          --enable-free-mon=off
+          --enterprise-features=fle
+          --js-engine=none
+          --link-model=static
+          DESTDIR='$BUILD_ROOT/csfle-lib-$MONGO_VERSION'
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/mongo-csfle-shlib-test-runtime.${ext|tgz}"
+        remote_file: "${project}/mongo_csfle/${build_variant}/${revision}/mongo_csfle_shlib_test-${version}.${ext|tgz}"
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/tar}
+        display_name: "Mongo CSFLE Shared Library Test"
+
+- name: csfle_run_tests
+  tags: []
+  depends_on:
+    - name: csfle_install_tests
+  commands:
+    - *f_expansions_write
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/csfle_run_tests.sh"
+
+- name: compile_benchmarks
+  tags: []
+  depends_on: []
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "get buildnumber"
+    - func: "f_expansions_write"
+    - func: "set up credentials"
+    - func: "use WiredTiger develop" # noop if ${use_wt_develop} is not "true"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+    # Then we load the generated version data into the agent so we can use it in task definitions
+    - func: "apply compile expansions"
+    - func: "scons compile"
+      vars:
+        targets: install-benchmarks
+        compiling_for_test: true
+    - func: "attach scons logs"
+    - command: archive.targz_pack
+      params:
+        target: "benchmarks.tgz"
+        source_dir: "src"
+        include:
+          - "./build/benchmarks.txt"
+          - "./build/**_bm"
+          - "./build/**_bm.gcno"
+          - "./build/**_bm.exe"
+          - "./build/**_bm.pdb"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: benchmarks.tgz
+        remote_file: ${project}/${build_variant}/${revision}/benchmarks/${build_id}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: Benchmarks
+
+## lint ##
+- name: lint_pylinters
+  tags: ["lint"]
+  commands:
+    - command: timeout.update
+      params:
+        # 40 minutes
+        exec_timeout_secs: 2400
+    - *f_expansions_write
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "scons lint"
+      vars:
+        targets: lint-pylinters
+
+- name: lint_clang_format
+  tags: ["lint"]
+  commands:
+    - command: timeout.update
+      params:
+        # 40 minutes
+        exec_timeout_secs: 2400
+    - *f_expansions_write
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "scons lint"
+      vars:
+        targets: lint-clang-format
+
+- name: lint_eslint
+  tags: ["lint"]
+  commands:
+    - command: timeout.update
+      params:
+        # 40 minutes
+        exec_timeout_secs: 2400
+    - *f_expansions_write
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "scons lint"
+      vars:
+        targets: lint-eslint
+
+- name: lint_cpplint
+  tags: ["lint"]
+  commands:
+    - command: timeout.update
+      params:
+        # 40 minutes
+        exec_timeout_secs: 2400
+    - *f_expansions_write
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "scons lint"
+      vars:
+        targets: lint-lint.py
+
+- name: lint_yaml
+  tags: ["lint"]
+  depends_on: []
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "f_expansions_write"
+  - command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/lint_yaml.sh"
+
+- name: lint_shellscripts
+  tags: ["lint"]
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/lint_shellscripts.sh"
+
+- name: lint_errorcodes
+  tags: ["lint"]
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "scons lint"
+      vars:
+        targets: lint-errorcodes
+
+- name: test_api_version_compatibility
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "do setup"
+    - func: "f_expansions_write"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/check_idl_compat.sh"
+
+- name: burn_in_tests_gen
+  tags: []
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/burn_in_tests.sh"
+      env:
+        BURN_IN_TESTS: ${burn_in_tests}
+  - command: archive.targz_pack
+    params:
+      target: src/burn_in_tests_gen.tgz
+      source_dir: src
+      include:
+        - burn_in_tests_gen.json
+
+  - command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: src/burn_in_tests_gen.tgz
+      remote_file: ${project}/${build_variant}/${revision}/burn_in_tests_gen/burn_in_tests_gen-${build_id}.tgz
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/gzip
+      display_name: Burn_in_tests Task Config - Execution ${execution}
+  - command: generate.tasks
+    params:
+      files:
+        - src/burn_in_tests_gen.json
+
+- <<: *benchmark_template
+  name: benchmarks_orphaned
+  tags: ["benchmarks"]
+  commands:
+  - func: "do benchmark setup"
+  - func: "run tests"
+    vars:
+      suite: benchmarks
+      exec_timeout_secs: 10800  # 3 hour timeout.
+      resmoke_jobs_max: 1
+  - func: "send benchmark results"
+  - func: "analyze benchmark results"
+    vars:
+      suite: benchmarks
+
+- <<: *benchmark_template
+  name: benchmarks_sharding
+  tags: ["benchmarks"]
+  commands:
+  - func: "do benchmark setup"
+  - func: "run tests"
+    vars:
+      suite: benchmarks_sharding
+      resmoke_jobs_max: 1
+  - func: "send benchmark results"
+  - func: "analyze benchmark results"
+
+- <<: *benchmark_template
+  name: benchmarks_cst
+  tags: ["benchmarks"]
+  commands:
+  - func: "do benchmark setup"
+  - func: "run tests"
+    vars:
+      suite: benchmarks_cst
+      resmoke_jobs_max: 1
+  - func: "send benchmark results"
+  - func: "analyze benchmark results"
+
+- <<: *run_jepsen_template
+  name: jepsen_register_findAndModify
+  tags: ["jepsen"]
+  commands:
+  - func: "do setup"
+  - func: "do jepsen setup"
+  - func: "run jepsen test"
+    vars:
+      <<: *jepsen_config_vars
+      jepsen_read_with_find_and_modify: --read-with-find-and-modify
+      jepsen_storage_engine: --storage-engine wiredTiger
+      jepsen_test_name: register
+
+- <<: *run_jepsen_template
+  name: jepsen_register_linearizableRead
+  tags: ["jepsen"]
+  commands:
+  - func: "do setup"
+  - func: "do jepsen setup"
+  - func: "run jepsen test"
+    vars:
+      <<: *jepsen_config_vars
+      jepsen_read_concern: --read-concern linearizable
+      jepsen_storage_engine: --storage-engine wiredTiger
+      jepsen_test_name: register
+
+- <<: *run_jepsen_template
+  name: jepsen_set_linearizableRead
+  tags: ["jepsen"]
+  commands:
+  - func: "do setup"
+  - func: "do jepsen setup"
+  - func: "run jepsen test"
+    vars:
+      <<: *jepsen_config_vars
+      jepsen_read_concern: --read-concern linearizable
+      jepsen_storage_engine: --storage-engine wiredTiger
+      jepsen_test_name: set
+
+- <<: *run_jepsen_template
+  name: jepsen_read-concern-majority
+  tags: ["jepsen"]
+  commands:
+  - func: "do setup"
+  - func: "do jepsen setup"
+  - func: "run jepsen test"
+    vars:
+      <<: *jepsen_config_vars
+      jepsen_storage_engine: --storage-engine wiredTiger
+      jepsen_test_name: read-concern-majority
+
+# Smoke test to ensure the Server still works with Jepsen
+- <<: *run_jepsen_template
+  name: jepsen-smoke
+  tags: []
+  commands:
+    - func: "do setup"
+    - func: "do jepsen setup"
+    - func: "run jepsen test"
+      vars:
+        <<: *jepsen_config_vars
+        jepsen_storage_engine: --storage-engine wiredTiger
+        jepsen_test_name: read-concern-majority
+        jepsen_time_limit: --time-limit 120
+
+- <<: *run_jepsen_template
+  name: jepsen_read-concern-majority_w1
+  tags: ["jepsen"]
+  commands:
+  - func: "do setup"
+  - func: "do jepsen setup"
+  - func: "run jepsen test"
+    vars:
+      <<: *jepsen_config_vars
+      jepsen_storage_engine: --storage-engine wiredTiger
+      jepsen_test_name: read-concern-majority
+      jepsen_write_concern: --write-concern w1
+
+- <<: *run_jepsen_template
+  name: jepsen_list-append
+  tags: ["jepsen_docker"]
+  commands:
+  - func: "do setup"
+  - func: "do jepsen docker setup"
+  - func: "run jepsen docker test"
+
+## initial sync multiversion fuzzer ##
+- <<: *jstestfuzz_template
+  name: initial_sync_multiversion_fuzzer_gen
+  tags: ["multiversion_fuzzer", "require_npm", "random_name", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: initsync-fuzzer
+      suite: initial_sync_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## initial sync generational fuzzer ##
+- <<: *jstestfuzz_template
+  name: initial_sync_fuzzer_gen
+  tags: ["require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: initsync-fuzzer
+      suite: initial_sync_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## Standalone generational fuzzer for multiversion aggregation pipelines ##
+- <<: *jstestfuzz_template
+  name: aggregation_multiversion_fuzzer_gen
+  tags: ["aggfuzzer", "common", "multiversion", "require_npm", "random_name", "future_git_tag_incompatible"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      npm_command: agg-fuzzer
+
+## Standalone generational fuzzer for multiversion aggregation expressions ##
+- <<: *jstestfuzz_template
+  name: aggregation_expression_multiversion_fuzzer_gen
+  tags: ["aggfuzzer", "multiversion", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      npm_command: agg-expr-fuzzer
+
+## Standalone generational fuzzer for checking optimized and unoptimized expression equivalence
+- <<: *jstestfuzz_template
+  name: aggregation_expression_optimization_fuzzer_gen
+  tags: ["aggfuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode optimization
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      npm_command: agg-expr-fuzzer
+
+## Standalone generational fuzzer for checking optimized and unoptimized aggregation pipelines
+- <<: *jstestfuzz_template
+  name: aggregation_optimization_fuzzer_gen
+  tags: ["aggfuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode optimization
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      npm_command: agg-fuzzer
+
+## Standalone fuzzer for checking wildcard index correctness ##
+- <<: *jstestfuzz_template
+  name: aggregation_wildcard_fuzzer_gen
+  tags: ["aggfuzzer", "common", "wildcard", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode wildcard
+      npm_command: agg-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## Standalone fuzzer for checking timeseries optimizations correctness ##
+- <<: *jstestfuzz_template
+  name: aggregation_timeseries_fuzzer_gen
+  tags: ["aggfuzzer", "common", "timeseries", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode timeseries
+      npm_command: agg-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## Standalone generational fuzzer for checking optimized and unoptimized change stream pipelines ##
+- <<: *jstestfuzz_template
+  name: change_stream_optimization_fuzzer_gen
+  tags: ["change_stream_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode optimization
+      npm_command: change-stream-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz standalone fuzzer for checking find and aggregate equivalence ##
+- <<: *jstestfuzz_template
+  name: query_fuzzer_standalone_gen
+  tags: ["query_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode standalone
+      npm_command: query-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz sharded fuzzer for checking find and aggregate equivalence ##
+- <<: *jstestfuzz_template
+  name: query_fuzzer_sharded_gen
+  tags: ["query_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode sharded
+      npm_command: query-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz standalone update generational fuzzer ##
+- <<: *jstestfuzz_template
+  name: update_fuzzer_gen
+  tags: ["updatefuzzer", "require_npm", "random_name", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      npm_command: update-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz standalone update time-series generational fuzzer ##
+- <<: *jstestfuzz_template
+  name: update_timeseries_fuzzer_gen
+  tags: ["updatefuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --diffTestingMode timeseries
+      npm_command: update-fuzzer
+      suite: generational_fuzzer
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz replication update generational fuzzer ##
+- <<: *jstestfuzz_template
+  name: update_fuzzer_replication_gen
+  tags: ["updatefuzzer", "require_npm", "random_name", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      npm_command: update-fuzzer
+      suite: generational_fuzzer_replication
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## rollback multiversion fuzzer ##
+- <<: *jstestfuzz_template
+  name: rollback_multiversion_fuzzer_gen
+  tags: ["multiversion_fuzzer", "require_npm", "random_name", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 3
+      num_tasks: 5
+      npm_command: rollback-fuzzer
+      suite: rollback_fuzzer
+      # Rollback suites create indexes with majority of nodes not available for replication. So, disabling
+      # index build commit quorum.
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}, enableIndexBuildCommitQuorum: false}'"
+
+## rollback generational fuzzer ##
+- <<: *jstestfuzz_template
+  name: rollback_fuzzer_gen
+  tags: ["rollbackfuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 3
+      num_tasks: 5
+      npm_command: rollback-fuzzer
+      suite: rollback_fuzzer
+      # Rollback suites create indexes with majority of nodes not available for replication. So, disabling
+      # index build commit quorum.
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}, enableIndexBuildCommitQuorum: false}'"
+
+## rollback generational fuzzer with clean shutdowns ##
+- <<: *jstestfuzz_template
+  name: rollback_fuzzer_clean_shutdowns_gen
+  tags: ["rollbackfuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 1
+      num_tasks: 4
+      jstestfuzz_vars: --numLinesPerFile 300 --maxLinesBetweenEvents 50
+      npm_command: rollback-fuzzer
+      suite: rollback_fuzzer_clean_shutdowns
+      # Rollback suites create indexes with majority of nodes not available for replication. So, disabling
+      # index build commit quorum.
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}, enableIndexBuildCommitQuorum: false}'"
+
+## rollback generational fuzzer with unclean shutdowns ##
+- <<: *jstestfuzz_template
+  name: rollback_fuzzer_unclean_shutdowns_gen
+  tags: ["rollbackfuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 1
+      num_tasks: 4
+      jstestfuzz_vars: --numLinesPerFile 300 --maxLinesBetweenEvents 50
+      npm_command: rollback-fuzzer
+      suite: rollback_fuzzer_unclean_shutdowns
+      # Rollback suites create indexes with majority of nodes not available for replication. So, disabling
+      # index build commit quorum.
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}, enableIndexBuildCommitQuorum: false}'"
+
+## jstestfuzz ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_gen
+  tags: ["jstestfuzz", "common", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      npm_command: jstestfuzz
+
+## jstestfuzz concurrent ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_gen
+  tags: ["jstestfuzz", "common", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz
+      resmoke_args: --numClientsPerFixture=10
+
+## jstestfuzz concurrent replica set ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_replication_gen
+  tags: ["jstestfuzz", "common", "repl", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication
+      resmoke_args: --numClientsPerFixture=10
+
+## jstestfuzz concurrent replica set with logical session ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_replication_session_gen
+  tags: ["jstestfuzz", "session", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_session
+      resmoke_args: --numClientsPerFixture=10
+
+## jstestfuzz concurrent sharded cluster ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_sharded_gen
+  tags: ["jstestfuzz", "common", "sharding", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded
+      resmoke_args: --numClientsPerFixture=10
+
+## jstestfuzz concurrent sharded cluster causal consistency ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_sharded_causal_consistency_gen
+  tags: ["jstestfuzz", "causal", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_causal_consistency
+      resmoke_args: --numClientsPerFixture=10
+
+## jstestfuzz concurrent sharded cluster continuous stepdown ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_sharded_continuous_stepdown_gen
+  tags: ["jstestfuzz", "stepdowns", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 2
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_continuous_stepdown
+      resmoke_args: --numClientsPerFixture=10
+
+## jstestfuzz concurrent sharded cluster with logical session ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_sharded_session_gen
+  tags: ["jstestfuzz", "session", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: ${jstestfuzz_concurrent_num_files|10}
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_session
+      resmoke_args: --numClientsPerFixture=10
+
+# jstestfuzz interrupt #
+- <<: *jstestfuzz_template
+  name: jstestfuzz_interrupt_gen
+  tags: ["jstestfuzz", "interrupt", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_interrupt
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+# jstestfuzz interrupt #
+- <<: *jstestfuzz_template
+  name: jstestfuzz_interrupt_replication_gen
+  tags: ["jstestfuzz", "interrupt", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_interrupt_replication
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+# jstestfuzz write conflict #
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_write_conflicts_gen
+  tags: ["jstestfuzz", "write_conflict", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_write_conflicts
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+# jstestfuzz concurrent conflict #
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_replication_write_conflicts_gen
+  tags: ["jstestfuzz", "write_conflict", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_write_conflicts
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}' --numClientsPerFixture=10"
+
+# jstestfuzz interrupt with flow control engaged #
+- <<: *jstestfuzz_template
+  name: jstestfuzz_interrupt_replication_flow_control_gen
+  tags: ["jstestfuzz", "interrupt", "flow_control", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 2
+      num_tasks: 1
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_interrupt_replication
+      resmoke_args: "--flowControlTicketOverride=1 --mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz sharded cluster continuous stepdown with flow control engaged ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_sharded_continuous_stepdown_flow_control_gen
+  tags: ["jstestfuzz", "flow_control", "stepdowns", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 2
+      num_tasks: 1
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_continuous_stepdown
+      resmoke_args: >-
+          --flowControlTicketOverride=3
+          --mongodSetParameters="{logComponentVerbosity: {command: 2}}"
+
+## jstestfuzz concurrent sharded cluster continuous stepdown with flow control engaged ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_sharded_continuous_stepdown_flow_control_gen
+  tags: ["jstestfuzz", "flow_control", "stepdowns", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 2
+      num_tasks: 1
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_continuous_stepdown
+      resmoke_args: >-
+          --flowControlTicketOverride=30
+          --numClientsPerFixture=10
+
+# jstestfuzz replication continuous stepdown with flow control engaged #
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_continuous_stepdown_flow_control_gen
+  tags: ["jstestfuzz", "repl", "flow_control", "stepdowns", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 2
+      num_tasks: 1
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_continuous_stepdown
+      resmoke_args: >-
+          --flowControlTicketOverride=1
+          --mongodSetParameters="{logComponentVerbosity: {command: 2}}"
+
+## jstestfuzz concurrent replication continuous stepdown with flow control engaged ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_concurrent_replication_continuous_stepdown_flow_control_gen
+  tags: ["jstestfuzz", "repl", "flow_control", "stepdowns", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 2
+      num_tasks: 1
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_continuous_stepdown
+      resmoke_args: >-
+          --flowControlTicketOverride=10
+          --numClientsPerFixture=10
+
+## jstestfuzz replica set ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_gen
+  tags: ["jstestfuzz", "common", "repl", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz replica set multiversion ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_multiversion_gen
+  tags: ["multiversion_fuzzer", "require_npm", "random_name", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      suite: jstestfuzz_replication
+      npm_command: jstestfuzz
+
+## jstestfuzz initial sync replica set ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_initsync_gen
+  tags: ["jstestfuzz", "initsync", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 8
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_initsync
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz file copy based initial sync replica set ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_fcbis_gen
+  tags: ["jstestfuzz", "initsync", "fcbis", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 8
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_fcbis
+      resmoke_args: --storageEngine=wiredTiger
+      name: jstestfuzz_replication_fcbis
+
+## jstestfuzz replica set with logical session ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_replication_session_gen
+  tags: ["jstestfuzz", "session", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_replication_session
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz sharded cluster ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_sharded_gen
+  tags: ["jstestfuzz", "common", "sharding", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz sharded multiversion cluster ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_sharded_multiversion_gen
+  tags: ["multiversion_fuzzer", "require_npm", "random_name", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+      suite: jstestfuzz_sharded
+      npm_command: jstestfuzz
+
+## jstestfuzz sharded cluster causal consistency ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_sharded_causal_consistency_gen
+  tags: ["jstestfuzz", "causal", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_causal_consistency
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz sharded cluster continuous stepdown ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_sharded_continuous_stepdown_gen
+  tags: ["jstestfuzz", "stepdowns", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 5
+      num_tasks: 5
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_continuous_stepdown
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## jstestfuzz sharded cluster with logical session ##
+- <<: *jstestfuzz_template
+  name: jstestfuzz_sharded_session_gen
+  tags: ["jstestfuzz", "session", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      jstestfuzz_vars: --jsTestsDir ../jstests
+      suite: jstestfuzz_sharded_session
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {command: 2}}'"
+
+## resharding generational fuzzer ##
+- <<: *jstestfuzz_template
+  name: resharding_fuzzer_inplace_gen
+  tags: ["resharding_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: resharding-fuzzer
+      jstestfuzz_vars: --numDonors 2 --numRecipients 2 --inPlace yes
+      suite: resharding_fuzzer
+
+- <<: *jstestfuzz_template
+  name: resharding_fuzzer_split_gen
+  tags: ["resharding_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: resharding-fuzzer
+      jstestfuzz_vars: --numDonors 1 --numRecipients 2 --inPlace no
+      suite: resharding_fuzzer
+
+- <<: *jstestfuzz_template
+  name: resharding_fuzzer_merge_gen
+  tags: ["resharding_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: resharding-fuzzer
+      jstestfuzz_vars: --numDonors 2 --numRecipients 1 --inPlace no
+      suite: resharding_fuzzer
+
+- <<: *jstestfuzz_template
+  name: resharding_fuzzer_shuffle_gen
+  tags: ["resharding_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: resharding-fuzzer
+      jstestfuzz_vars: --numDonors 3 --numRecipients 3 --inPlace no
+      suite: resharding_fuzzer
+
+- <<: *jstestfuzz_template
+  name: resharding_fuzzer_idempotency_gen
+  tags: ["resharding_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: resharding-fuzzer
+      jstestfuzz_vars: --numDonors 3 --numRecipients 3 --inPlace no
+      suite: resharding_fuzzer_idempotency
+
+- <<: *jstestfuzz_template
+  name: resharding_fuzzer_stepup_gen
+  tags: ["resharding_fuzzer", "require_npm", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      <<: *jstestfuzz_config_vars
+      num_files: 10
+      num_tasks: 5
+      npm_command: resharding-fuzzer
+      jstestfuzz_vars: >-
+        --numDonors 3 --numRecipients 3 --inPlace yes
+        --electionMech stepup --electionRole donor --electionRole recipient
+      suite: resharding_fuzzer
+
+## Tests that the multiversion test generation logic is not broken.
+- <<: *gen_task_template
+  name: multiversion_sanity_check_gen
+  tags: ["multiversion", "multiversion_sanity_check"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_jscore_multiversion_gen
+  tags: ["multiversion", "multiversion_passthrough"]
+  commands:
+    - func: "generate resmoke tasks"
+      vars:
+        suite: replica_sets_jscore_passthrough
+
+
+# Check that the mutational fuzzer can parse JS files modified in a patch build.
+- name: lint_fuzzer_sanity_patch
+  tags: []
+  patch_only: true
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - *set_up_venv
+  - func: "get added and modified patch files"
+  - func: "setup jstestfuzz"
+  - func: "lint fuzzer sanity patch"
+
+# Check that the mutational fuzzer can parse all JS filess.
+- name: lint_fuzzer_sanity_all
+  tags: []
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - *set_up_venv
+  - func: "setup jstestfuzz"
+  - func: "lint fuzzer sanity all"
+
+## integration test suites ##
+
+- <<: *task_template
+  name: aggregation
+  tags: ["aggregation", "common"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_disabled_optimization
+  tags: ["aggregation", "common"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_ese
+  tags: ["aggregation", "encrypt"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_ese_gcm
+  tags: ["aggregation", "encrypt", "gcm"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_auth
+  tags: ["aggregation", "auth", "common"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_facet_unwind_passthrough
+  tags: ["aggregation", "unwind"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_mongos_passthrough
+  tags: ["aggregation", "no_async"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_one_shard_sharded_collections
+  tags: ["aggregation", "no_async", "sharded"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_read_concern_majority_passthrough
+  tags: ["aggregation", "read_write_concern"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_factor: 0.5
+
+- <<: *gen_task_template
+  name: aggregation_secondary_reads_gen
+  tags: ["aggregation", "secondary_reads"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+      resmoke_repeat_suites: 5
+
+- <<: *task_template
+  name: aggregation_sharded_collections_passthrough
+  tags: ["aggregation", "common", "sharded"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: aggregation_sharded_collections_causally_consistent_passthrough
+  tags: ["aggregation", "secondary_reads", "sharded"]
+  depends_on:
+  - name: aggregation
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: audit
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: auth_gen
+  tags: ["auth"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- name: burn_in_tags_gen
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - func: "generate burn in tags"
+    vars:
+      max_revisions: 25
+      repeat_tests_secs: 600
+      repeat_tests_min: 2
+      repeat_tests_max: 1000
+
+- name: build_variant_gen
+  commands:
+    - command: manifest.load
+    - *git_get_project
+    - *f_expansions_write
+    - *add_git_tag
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "generate build variant"
+
+- name: selected_tests_gen
+  tags: []
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "generate selected tests"
+
+- <<: *gen_task_template
+  name: auth_audit_gen
+  tags: ["auth", "audit"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *task_template
+  name: change_streams
+  tags: ["change_streams"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: change_streams_multiversion_gen
+  tags: ["multiversion", "multiversion_passthrough"]
+  commands:
+    - func: "generate resmoke tasks"
+      vars:
+        suite: change_streams
+
+- <<: *gen_task_template
+  name: change_streams_downgrade_gen
+  tags: ["multiversion_passthrough", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *task_template
+  name: change_streams_update_v1_oplog
+  tags: ["change_streams"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_mongos_sessions_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_mongos_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_secondary_reads
+  tags: ["change_streams", "secondary_reads"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_sharded_collections_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: change_streams_sharded_collections_multiversion_gen
+  tags: ["multiversion_passthrough", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: change_streams_sharded_collections_passthrough
+
+- <<: *gen_task_template
+  name: multiversion_future_git_tag_gen
+  tags: ["multiversion", "no_version_combination", "multiversion_future_git_tag"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: multiversion_future_git_tag
+
+- <<: *gen_task_template
+  name: multiversion_auth_future_git_tag_gen
+  tags: ["auth", "multiversion", "no_version_combination", "multiversion_future_git_tag"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: multiversion_auth_future_git_tag
+
+- <<: *task_template
+  name: change_streams_whole_db_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_db_mongos_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams_mongos_passthrough
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_db_secondary_reads_passthrough
+  tags: ["change_streams", "secondary_reads"]
+  depends_on:
+  - name: change_streams_secondary_reads
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_db_sharded_collections_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams_sharded_collections_passthrough
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_cluster_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_cluster_mongos_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams_mongos_passthrough
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_cluster_secondary_reads_passthrough
+  tags: ["change_streams", "secondary_reads"]
+  depends_on:
+  - name: change_streams_secondary_reads
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_whole_cluster_sharded_collections_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams_sharded_collections_passthrough
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_multi_stmt_txn_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_multi_stmt_txn_mongos_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_multi_stmt_txn_sharded_collections_passthrough
+  tags: ["change_streams"]
+  depends_on:
+  - name: change_streams
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: change_streams_per_shard_cursor_passthrough
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: disk_wiredtiger
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: ese
+  tags: ["encrypt"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: failpoints
+  tags: ["misc_js"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: failpoints_auth
+  tags: ["auth"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: integration_tests_standalone
+  tags: ["integration", "standalone"]
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "do setup"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"  # Generate compile expansions needs to be run to mount the shared scons cache.
+  - func: "apply compile expansions"
+  - func: "scons compile"
+    vars:
+      targets: install-integration-tests
+      compiling_for_test: true
+  - func: "attach scons logs"
+  - func: "run tests"
+
+- <<: *task_template
+  name: integration_tests_standalone_audit
+  tags: ["integration", "audit"]
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "do setup"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"  # Generate compile expansions needs to be run to mount the shared scons cache.
+  - func: "apply compile expansions"
+  - func: "scons compile"
+    vars:
+      targets: install-integration-tests
+      compiling_for_test: true
+  - func: "attach scons logs"
+  - func: "run tests"
+
+- <<: *task_template
+  name: integration_tests_replset
+  tags: ["integration"]
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "do setup"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"  # Generate compile expansions needs to be run to mount the shared scons cache.
+  - func: "apply compile expansions"
+  - func: "scons compile"
+    vars:
+      targets: install-integration-tests
+      compiling_for_test: true
+  - func: "attach scons logs"
+  - func: "run tests"
+
+- <<: *task_template
+  name: integration_tests_replset_ssl_auth
+  tags: ["integration"]
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "do setup"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"  # Generate compile expansions needs to be run to mount the shared scons cache.
+  - func: "apply compile expansions"
+  - func: "scons compile"
+    vars:
+      targets: install-integration-tests
+      compiling_for_test: true
+  - func: "attach scons logs"
+  - func: "run tests"
+
+- <<: *task_template
+  name: integration_tests_sharded
+  tags: ["integration", "sharded"]
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - func: "do setup"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"  # Generate compile expansions needs to be run to mount the shared scons cache.
+  - func: "apply compile expansions"
+  - func: "scons compile"
+    vars:
+      targets: install-integration-tests
+      compiling_for_test: true
+  - func: "attach scons logs"
+  - func: "run tests"
+
+- <<: *task_template
+  name: external_auth
+  tags: []
+  commands:
+  - *f_expansions_write
+  - func: "do setup"
+  - func: "f_expansions_write"
+  - command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/external_auth_pip.sh"
+  - func: "run tests"
+    vars:
+      # TODO SERVER-64323
+      # restore concurrency for this suite when the issue on windows is resolved.
+      resmoke_jobs_max: 1
+      resmoke_args: --excludeWithAnyTags=requires_domain_controller
+
+- <<: *task_template
+  name: external_auth_aws
+  tags: []
+  commands:
+  - *f_expansions_write
+  - func: "do setup"
+  - func: "f_expansions_write"
+  - command: subprocess.exec
+    params:
+      binary: bash
+      silent: true
+      args:
+        - "src/evergreen/external_auth_aws_setup.sh"
+  - command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/external_auth_aws_pip.sh"
+  - func: "run tests"
+
+
+- <<: *task_template
+  name: external_auth_windows
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: external_auth
+      resmoke_args: --includeWithAnyTags=requires_domain_controller
+
+- <<: *task_template
+  name: jsCore
+  tags: ["jscore", "common"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core
+
+- <<: *task_template
+  name: config_fuzzer_jsCore
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core
+      resmoke_args: --fuzzMongodConfigs
+
+- <<: *task_template
+  name: config_fuzzer_concurrency
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: concurrency
+      resmoke_args: --fuzzMongodConfigs
+
+- <<: *task_template
+  name: config_fuzzer_simulate_crash_concurrency_replication
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: simulate_crash_concurrency_replication
+      resmoke_args: --fuzzMongodConfigs
+
+- <<: *task_template
+  name: config_fuzzer_concurrency_replication
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: concurrency_replication
+      resmoke_args: --fuzzMongodConfigs
+
+- <<: *task_template
+  name: config_fuzzer_replica_sets_jscore_passthrough
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: replica_sets_jscore_passthrough
+      resmoke_args: --fuzzMongodConfigs
+
+- <<: *task_template
+  name: jsCore_ese
+  tags: ["jscore", "encrypt"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core_ese
+
+- <<: *task_template
+  name: jsCore_ese_gcm
+  tags: ["jscore", "encrypt", "gcm"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core_ese_gcm
+
+- <<: *task_template
+  name: jsCore_auth
+  tags: ["jscore", "auth", "common"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core_auth
+
+- <<: *task_template
+  name: jsCore_minimum_batch_size
+  tags: ["jscore"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core_minimum_batch_size
+
+- <<: *task_template
+  name: jsCore_txns
+  tags: ["jscore", "common", "txns"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core_txns
+
+- <<: *task_template
+  name: jsCore_txns_large_txns_format
+  tags: ["jscore", "txns", "multi_oplog"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: core_txns_large_txns_format
+
+- <<: *task_template
+  name: sharded_jscore_txns
+  tags: ["sharding", "jscore", "txns"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: sharded_jscore_txns_without_snapshot
+  tags: ["sharding", "wo_snapshot", "jscore"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: sharded_jscore_txns
+      resmoke_args: --excludeWithAnyTags=uses_snapshot_read_concern
+
+- <<: *task_template
+  name: sharded_jscore_txns_sharded_collections
+  tags: ["sharding", "jscore", "txns"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: cst_jscore_passthrough
+  tags: ["jscore"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: libunwind_tests
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: libunwind
+
+- <<: *task_template
+  name: causally_consistent_jscore_txns_passthrough
+  tags: ["causally_consistent"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: sharded_causally_consistent_jscore_txns_passthrough_gen
+  tags: ["sharding", "jscore", "causally_consistent", "txns"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: sharded_causally_consistent_jscore_txns_passthrough_without_snapshot_gen
+  tags: ["sharding", "wo_snapshot", "causally_consistent", "jscore"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: sharded_causally_consistent_jscore_txns_passthrough
+      resmoke_args: --excludeWithAnyTags=uses_snapshot_read_concern
+
+- <<: *gen_task_template
+  name: causally_consistent_hedged_reads_jscore_passthrough_gen
+  tags: ["causally_consistent", "sharding", "jscore"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *task_template
+  name: sharded_collections_causally_consistent_jscore_txns_passthrough
+  tags: ["sharding", "jscore", "causally_consistent", "txns"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: replica_sets_jscore_passthrough
+  tags: ["replica_sets", "common", "san", "large", "ignore_non_generated_replica_sets_jscore_passthrough"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: replica_sets_reconfig_jscore_passthrough_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_api_version_jscore_passthrough_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      fallback_num_sub_suites: 5
+
+- <<: *gen_task_template
+  name: replica_sets_jscore_passthrough_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *task_template
+  name: replica_sets_large_txns_format_jscore_passthrough
+  tags: ["replica_sets", "multi_oplog", "large", "non_maj_read", "san"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: replica_sets_multi_stmt_txn_jscore_passthrough
+  tags: ["replica_sets", "large"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: replica_sets_multi_stmt_txn_stepdown_jscore_passthrough_gen
+  tags: ["replica_sets", "non_maj_read"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: replica_sets_multi_stmt_txn_kill_primary_jscore_passthrough_gen
+  tags: ["replica_sets", "non_maj_read", "non_live_record"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *task_template
+  name: replica_sets_multi_stmt_txn_terminate_primary_jscore_passthrough
+  tags: ["replica_sets", "non_maj_read"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: replica_sets_update_v1_oplog_jscore_passthrough_gen
+  tags: ["replica_sets", "non_maj_read"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_initsync_jscore_passthrough_gen
+  tags: ["replica_sets", "san", "large"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_fcbis_jscore_passthrough_gen
+  tags: ["replica_sets", "fcbis", "large"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_args: --storageEngine=wiredTiger
+
+- <<: *task_template
+  name: replica_sets_initsync_static_jscore_passthrough
+  tags: ["replica_sets", "san", "large"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: replica_sets_kill_primary_jscore_passthrough_gen
+  tags: ["replica_sets", "large", "non_maj_read", "non_live_record"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *task_template
+  name: replica_sets_terminate_primary_jscore_passthrough
+  tags: ["replica_sets", "large", "non_maj_read"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: replica_sets_kill_secondaries_jscore_passthrough
+  tags: ["replica_sets", "san", "large", "non_live_record"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: mongosTest
+  tags: ["misc_js", "non_read_maj", "non_live_record"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: mongos_test
+
+- <<: *gen_task_template
+  name: multiversion_auth_gen
+  tags: ["auth", "multiversion", "no_version_combination", "future_git_tag_incompatible"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: multiversion_gen
+  tags: ["multiversion", "no_version_combination", "future_git_tag_incompatible"]
+  commands:
+  - func: "generate resmoke tasks"
+
+# Tests the runFeatureFlagMultiversionTest helper.
+# This requires the 'featureFlagToaster' and 'featureFlagSpoon' parameters to be set to true on
+# build variants that enable this task.
+- <<: *gen_task_template
+  name: feature_flag_multiversion_gen
+  tags: ["multiversion", "no_version_combination"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: unittest_shell_hang_analyzer_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: noPassthrough_gen
+  tags: ["misc_js"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: no_passthrough
+      use_large_distro: "true"
+
+# Only run hot_backups tests for hot_backups variant.
+- <<: *gen_task_template
+  name: noPassthroughHotBackups_gen
+  tags: []
+  commands:
+    - func: "generate resmoke tasks"
+      vars:
+        suite: no_passthrough
+        resmoke_args: src/mongo/db/modules/*/jstests/hot_backups/*.js
+        use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: noPassthroughWithMongod_gen
+  tags: ["misc_js"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: no_passthrough_with_mongod
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: slow1_gen
+  tags: ["misc_js", "non_win_dbg"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+      use_large_distro: "true"
+
+- <<: *task_template
+  name: serial_run
+  tags: ["misc_js", "non_win_dbg"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: sharded_collections_jscore_passthrough
+  tags: ["sharding", "jscore"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: sharded_collections_jscore_multiversion_gen
+  tags: ["multiversion_passthrough", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: sharded_collections_jscore_passthrough
+
+- <<: *task_template
+  name: sharding_jscore_passthrough
+  tags: ["sharding", "jscore", "common"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: sharding_jscore_multiversion_gen
+  tags: ["multiversion_passthrough", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: sharding_jscore_passthrough
+
+- <<: *gen_task_template
+  name: sharding_api_version_jscore_passthrough_gen
+  tags: ["sharding", "jscore"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      fallback_num_sub_suites: 5
+
+- <<: *task_template
+  name: sharding_update_v1_oplog_jscore_passthrough
+  tags: ["sharding", "jscore"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: sharding_jscore_passthrough
+
+- <<: *task_template
+  name: sharded_multi_stmt_txn_jscore_passthrough
+  tags: ["sharding", "jscore", "multi_stmt"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: multi_shard_multi_stmt_txn_jscore_passthrough_gen
+  tags: ["multi_shard", "multi_stmt", "common"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 0  # No cap on number of jobs.
+
+- <<: *gen_task_template
+  name: multi_shard_local_read_write_multi_stmt_txn_jscore_passthrough_gen
+  tags: ["multi_shard", "common"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  tags: ["multi_stmt"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: multi_shard_multi_stmt_txn_kill_primary_jscore_passthrough_gen
+  tags: ["multi_shard"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: multi_shard_multi_stmt_txn_stepdown_primary_jscore_passthrough_gen
+  tags: ["multi_shard"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: tenant_migration_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: talk_directly_to_shardsvrs_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: tenant_migration_causally_consistent_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: tenant_migration_multi_stmt_txn_jscore_passthrough_gen
+  tags: ["serverless", "txn"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: tenant_migration_stepdown_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: tenant_migration_terminate_primary_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      fallback_num_sub_suites: 10
+
+- <<: *gen_task_template
+  name: tenant_migration_kill_primary_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      fallback_num_sub_suites: 10
+
+- <<: *gen_task_template
+  name: clustered_collection_passthrough_gen
+  tags: ["large", "clustered_collections"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_clustered_collections_gen
+  tags: ["large", "clustered_collections"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: parallel_gen
+  tags: ["misc_js", "parallel"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_gen
+  tags: ["concurrency", "common"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_metrics_gen
+  tags: ["concurrency"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_replication_metrics_gen
+  tags: ["concurrency", "repl", "disabled_on_code_coverage"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_replication_gen
+  tags: ["concurrency", "common", "repl"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_replication_multiversion_gen
+  tags: ["multiversion", "multiversion_passthrough"]
+  commands:
+    - func: "generate resmoke tasks"
+      vars:
+        suite: concurrency_replication
+
+- <<: *gen_task_template
+  name: concurrency_replication_causal_consistency_gen
+  tags: ["concurrency", "repl", "large", "non_live_record"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: concurrency_replication_multi_stmt_txn_gen
+  tags: ["concurrency", "common", "repl", "txn"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+  # TODO: SERVER-35964 revert the addition of UBSAN concurrency_replication suites.
+- <<: *task_template
+  name: concurrency_replication_ubsan
+  tags: ["concurrency", "ubsan", "repl"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: concurrency_replication_causal_consistency_ubsan
+  tags: ["concurrency", "ubsan", "repl"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: concurrency_replication_multi_stmt_txn_ubsan
+  tags: ["concurrency", "ubsan", "repl"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_replication_wiredtiger_cursor_sweeps_gen
+  tags: ["concurrency", "repl"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_replication_wiredtiger_eviction_debug_gen
+  tags: ["concurrency", "repl", "debug_only"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_replication_gen
+  tags: ["concurrency", "common", "read_concern_maj", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_replication_multiversion_gen
+  tags: ["multiversion_passthrough", "sharded", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: concurrency_sharded_replication
+
+- <<: *gen_task_template
+  name: concurrency_sharded_replication_with_balancer_gen
+  tags: ["concurrency", "common", "read_concern_maj", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_replication_no_txns_gen
+  tags: ["concurrency", "no_txns", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: concurrency_sharded_replication
+      resmoke_args: "--excludeWithAnyTags=uses_transactions"
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_replication_no_txns_with_balancer_gen
+  tags: ["concurrency", "no_txns", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: concurrency_sharded_replication_with_balancer
+      resmoke_args: "--excludeWithAnyTags=uses_transactions"
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_clusterwide_ops_add_remove_shards_gen
+  tags: ["concurrency", "common", "read_concern_maj", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_causal_consistency_gen
+  tags: ["concurrency", "non_live_record", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_causal_consistency_and_balancer_gen
+  tags: ["concurrency", "large", "non_live_record", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_with_stepdowns_gen
+  tags: ["concurrency", "stepdowns", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_with_stepdowns_and_balancer_gen
+  tags: ["concurrency", "stepdowns", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_terminate_primary_with_balancer_gen
+  tags: ["concurrency", "stepdowns", "kill_terminate", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_kill_primary_with_balancer_gen
+  tags: ["concurrency", "stepdowns", "kill_terminate", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_multi_stmt_txn_gen
+  tags: ["concurrency", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_multi_stmt_txn_with_balancer_gen
+  tags: ["concurrency", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_local_read_write_multi_stmt_txn_gen
+  tags: ["concurrency", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer_gen
+  tags: ["concurrency", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_multi_stmt_txn_with_stepdowns_gen
+  tags: ["concurrency", "stepdowns", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_multi_stmt_txn_terminate_primary_gen
+  tags: ["concurrency", "stepdowns", "kill_terminate", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_sharded_multi_stmt_txn_kill_primary_gen
+  tags: ["concurrency", "stepdowns", "kill_terminate", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_simultaneous_gen
+  tags: ["concurrency", "common", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: concurrency_simultaneous_replication_gen
+  tags: ["concurrency", "common", "large", "repl", "random_name"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: concurrency_simultaneous_replication_wiredtiger_cursor_sweeps
+  tags: ["concurrency", "repl", "random_name"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: concurrency_simultaneous_replication_wiredtiger_eviction_debug
+  tags: ["concurrency", "repl", "debug_only", "random_name"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: read_concern_linearizable_passthrough
+  tags: ["read_write_concern", "linearize", "large"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: read_concern_majority_passthrough_gen
+  tags: ["read_write_concern"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *task_template
+  name: write_concern_majority_passthrough
+  tags: ["read_write_concern", "large", "write"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: cwrwc_passthrough
+  tags: ["read_write_concern", "large", "write"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: cwrwc_rc_majority_passthrough_gen
+  tags: ["read_write_concern"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *task_template
+  name: cwrwc_wc_majority_passthrough
+  tags: ["read_write_concern", "large", "write"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: secondary_reads_passthrough_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: replica_sets_gen
+  tags: ["replica_sets", "san", "large"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_ese_gen
+  tags: ["replica_sets", "encrypt", "san"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: replica_sets_ese_gcm_gen
+  tags: ["replica_sets", "encrypt", "san", "gcm"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: replica_sets_auth_gen
+  tags: ["replica_sets", "common", "san", "auth"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: replica_sets_large_txns_format_gen
+  tags: ["replica_sets", "multi_oplog", "san"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_max_mirroring_gen
+  tags: ["replica_sets", "san"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_update_v1_oplog_gen
+  tags: ["replica_sets", "san"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: replica_sets_multiversion_gen
+  tags: ["random_multiversion_ds", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: replica_sets
+
+- <<: *task_template
+  name: sasl
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: serverless
+  tags: ["serverless"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: sharding_gen
+  tags: ["sharding", "common"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_multiversion_gen
+  tags: ["random_multiversion_ds", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      suite: sharding
+
+- <<: *gen_task_template
+  name: sharding_max_mirroring_gen
+  tags: ["sharding", "common"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_csrs_continuous_config_stepdown_gen
+  tags: ["sharding", "common", "csrs", "non_live_record"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: sharding_continuous_config_stepdown
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_ese_gen
+  tags: ["sharding", "encrypt"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_ese_gcm_gen
+  tags: ["sharding", "encrypt", "gcm"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_auth_gen
+  tags: ["sharding", "auth"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_auth_audit_gen
+  tags: ["auth", "audit", "non_live_record"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_hello_failures_gen
+  tags: ["concurrency", "large", "sharded"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+      resmoke_jobs_max: 1
+
+- <<: *gen_task_template
+  name: sharding_last_lts_mongos_and_mixed_shards_gen
+  tags: ["sharding", "common", "multiversion", "no_version_combination"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
+  name: sharding_update_v1_oplog_gen
+  tags: ["sharding", "common"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *task_template
+  name: snmp
+  tags: []
+  commands:
+  - *f_expansions_write
+  - func: "do setup"
+  - func: "do snmp setup"
+  - func: "run tests"
+    vars:
+      snmp_config_path: SNMPCONFPATH=snmpconf
+
+- <<: *gen_task_template
+  name: ssl_gen
+  tags: ["encrypt", "ssl"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      resmoke_args: "--mongodSetParameters='{logComponentVerbosity: {network: 2, replication: {heartbeats: 2}}}'"
+
+- <<: *gen_task_template
+  name: sslSpecial_gen
+  tags: ["encrypt", "ssl"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: ssl_special
+
+- <<: *gen_task_template
+  name: ssl_x509_gen
+  tags: ["encrypt", "ssl"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      suite: ssl_x509
+
+- <<: *task_template
+  name: jsCore_decimal
+  tags: ["jscore", "common", "decimal"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      suite: decimal
+
+- <<: *task_template
+  name: read_only
+  tags: ["read_only"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: read_only_sharded
+  tags: ["read_only"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: session_jscore_passthrough
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *gen_task_template
+  name: causally_consistent_jscore_passthrough_gen
+  tags: ["causally_consistent"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: causally_consistent_jscore_passthrough_auth_gen
+  tags: ["causally_consistent"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: causally_consistent_read_concern_snapshot_passthrough_gen
+  tags: ["causally_consistent", "read_write_concern", "durable_history"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: sharded_causally_consistent_read_concern_snapshot_passthrough_gen
+  tags: ["causally_consistent", "read_write_concern", "durable_history"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: sharded_causally_consistent_jscore_passthrough_gen
+  tags: ["causally_consistent"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: retryable_writes_jscore_passthrough_gen
+  tags: ["retry"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+# Use explicit task definitions for retryable_writes_downgrade suites to avoid running
+# with all Repl multiversion combinations.
+- <<: *gen_task_template
+  name: retryable_writes_downgrade_last_continuous_gen
+  tags: ["multiversion_passthrough", "multiversion", "no_version_combination"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: retryable_writes_downgrade_last_lts_gen
+  tags: ["multiversion_passthrough", "multiversion", "no_version_combination"]
+  commands:
+    - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: sharded_retryable_writes_downgrade_gen
+  tags: ["multiversion_passthrough", "multiversion"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_replication_default_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache", "repl"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_replication_100ms_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache", "repl"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_replication_1sec_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache", "one_sec", "repl"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_replication_10sec_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache", "repl"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_sharding_default_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_sharding_100ms_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_sharding_100ms_refresh_jscore_txns_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_sharding_1sec_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache", "one_sec"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_sharding_10sec_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_standalone_default_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_standalone_100ms_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_standalone_1sec_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache", "one_sec"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: logical_session_cache_standalone_10sec_refresh_jscore_passthrough_gen
+  tags: ["logical_session_cache"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *gen_task_template
+  name: retryable_writes_jscore_stepdown_passthrough_gen
+  tags: ["retry"]
+  commands:
+  - func: "generate resmoke tasks"
+
+- <<: *task_template
+  name: watchdog_wiredtiger
+  tags: ["watchdog"]
+  commands:
+  - *f_expansions_write
+  - func: "do setup"
+  - func: "do watchdog setup"
+  - func: "run tests"
+    vars:
+      suite: watchdog
+      resmoke_jobs_max: 1
+
+# This is a separate task because it is only supported on Ubuntu 16.04+ which are not inmemory builders
+- <<: *task_template
+  name: watchdog_inmemory
+  tags: ["watchdog"]
+  commands:
+  - *f_expansions_write
+  - func: "do setup"
+  - func: "do watchdog setup"
+  - func: "run tests"
+    vars:
+      suite: watchdog
+      resmoke_args: --storageEngine=inMemory
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: free_monitoring
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: client_encrypt
+  tags: ["ssl", "encrypt"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: fle
+  tags: ["encrypt"]
+  commands:
+  - func: "do setup"
+  - func: "load aws test credentials"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: fle2_query_analysis
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "load aws test credentials"
+  - func: "run tests"
+
+- <<: *task_template
+  name: fle2
+  tags: ["encrypt"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- <<: *task_template
+  name: ocsp
+  tags: ["ssl", "encrypt", "ocsp"]
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: json_schema
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- name: powercycle_gen
+  tags: []
+  commands:
+    - func: "generate powercycle tasks"
+      vars:
+        task_names: >-
+          powercycle
+          powercycle_kill_mongod
+          powercycle_replication_smalloplog
+          powercycle_syncdelay
+        num_tasks: 1
+
+- name: powercycle_smoke_skip_compile_gen
+  tags: []
+  commands:
+    - func: "generate powercycle tasks"
+      vars:
+        task_names: >-
+          powercycle_smoke_skip_compile
+        num_tasks: 20
+        exec_timeout_secs: 604800 # 7 days
+        timeout_secs: 604800 # 7 days
+        set_up_retry_count: 1800
+        run_powercycle_args: --sshAccessRetryCount=1800
+
+- name: powercycle_sentinel
+  tags: []
+  exec_timeout_secs: 604800 # 7 days
+  commands:
+    - func: "run powercycle sentinel"
+      vars:
+        gen_task: powercycle_smoke_skip_compile_gen
+
+- name: powercycle_smoke
+  tags: []
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle_kill_mongod
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle_last_lts_fcv
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle_replication
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle_replication_smalloplog
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle_syncdelay
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+- name: powercycle_write_concern_majority
+  tags: ["powercycle"]
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - func: "do setup"
+  - func: "set up remote credentials"
+    vars:
+      <<: *powercycle_remote_credentials
+  - func: "set up EC2 instance"
+  - func: "run powercycle test"
+    timeout_secs: 1800 # 30 minute timeout for no output
+
+
+- name: selinux_rhel8_org
+  tags: []
+  depends_on:
+  - name: package
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - func: "set up venv"
+  - func: "fetch packages"
+  - func: "run selinux tests"
+    vars:
+      distro: rhel80-selinux
+      test_list: jstests/selinux/*.js
+
+- name: selinux_rhel8_enterprise
+  tags: []
+  depends_on:
+  - name: package
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - func: "set up venv"
+  - func: "fetch packages"
+  - func: "run selinux tests"
+    vars:
+      distro: rhel80-selinux
+      test_list: jstests/selinux/*.js src/mongo/db/modules/enterprise/jstests/selinux/*.js
+
+- name: selinux_rhel7_org
+  tags: []
+  depends_on:
+  - name: package
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - func: "set up venv"
+  - func: "fetch packages"
+  - func: "run selinux tests"
+    vars:
+      user: root
+      distro: rhel76-selinux
+      test_list: jstests/selinux/*.js
+
+- name: selinux_rhel7_enterprise
+  tags: []
+  depends_on:
+  - name: package
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - func: "set up venv"
+  - func: "fetch packages"
+  - func: "run selinux tests"
+    vars:
+      user: root
+      distro: rhel76-selinux
+      test_list: jstests/selinux/*.js src/mongo/db/modules/enterprise/jstests/selinux/*.js
+
+- name: idl_tests
+  tags: []
+  depends_on:
+  - name: archive_dist_test
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "run idl tests"
+
+- name: blackduck_scanner
+  tags: []
+  patchable: false
+  commands:
+  - *f_expansions_write
+  - func: "do non-compile setup"
+  - command: subprocess.exec
+    type: setup
+    params:
+      binary: bash
+      silent: true
+      args:
+        - "src/evergreen/blackduck_setup.sh"
+  - command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/blackduck_hub.sh"
+
+- name: tla_plus
+  tags: []
+  commands:
+  - *f_expansions_write
+  - func: "do non-compile setup"
+  - command: subprocess.exec
+    type: setup
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/download_tlc.sh"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- name: buildscripts_test
+  tags: []
+  depends_on: []
+  commands:
+  - *f_expansions_write
+  - func: "do non-compile setup"
+  - func: "set up remote credentials"
+  - *f_expansions_write
+  - func: "configure evergreen api credentials"
+  - func: "do multiversion setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: resmoke_end2end_tests
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- name: test_packages
+  tags: []
+  depends_on:
+  - name: package
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - *set_up_venv
+    - func: "fetch packages"
+    - func: "set up remote credentials"
+      vars:
+        private_key_file: ~/.ssh/kitchen.pem
+        private_key_remote: ${kitchen_private_key}
+        aws_key_remote: ${kitchen_aws_key}
+        aws_secret_remote: ${kitchen_aws_secret}
+    - func: "run kitchen"
+
+- name: package
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - *set_up_venv
+    - func: "scons compile"
+      vars:
+        targets: >-
+          distsrc-${ext|tgz}
+          archive-dist
+          archive-dist-debug
+          archive-shell
+          archive-shell-debug
+          ${additional_package_targets|}
+        task_compile_flags: >-
+          --legacy-tarball
+    - func: "f_expansions_write"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/package.sh"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/distsrc.${ext|tgz}
+        remote_file: ${project}/${build_variant}/${revision}/sources/mongo-src-${build_id}.${ext|tgz}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Source tarball
+        # We only need to upload the source tarball from one of the build variants
+        # because it should be the same everywhere, so just use rhel70/windows.
+        build_variants: [rhel70, windows]
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-dist.${ext|tgz}
+        remote_file: ${project}/${build_variant}/${revision}/dist/mongo-${build_id}.${ext|tgz}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: Dist Tarball
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-dist-debugsymbols.${ext|tgz}
+        remote_file: ${project}/${build_variant}/${revision}/dist/mongo-${build_id}-debugsymbols.${ext|tgz}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: Dist Debugsymbols
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell.${ext|tgz}
+        remote_file: ${mongo_shell}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Shell
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell-debugsymbols.${ext|tgz}
+        remote_file: ${mongo_shell_debugsymbols}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Shell Debugsymbols
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd.${ext|tgz}
+        remote_file: ${mongo_cryptd}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: CryptD Binaries
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd-debugsymbols.${ext|tgz}
+        remote_file: ${mongo_cryptd_debugsymbols}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: CryptD Debugsymbols
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mh-binaries.${ext|tgz}
+        remote_file: ${mh_archive}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: MH Binaries
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mh-debugsymbols.${ext|tgz}
+        remote_file: ${mh_debugsymbols}
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: MH Debugsymbols
+    - func: "run packager.py"
+    - command: archive.targz_pack
+      params:
+        target: "packages.tgz"
+        source_dir: "src"
+        include:
+          - "repo/**"
+          - "./**.msi"
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: packages.tgz
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/${build_id}-packages.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/tar
+        display_name: Packages
+
+
+- name: publish_packages
+  tags: ["publish"]
+  # This should prevent this task from running in patch builds, where we
+  # don't want to publish packages.
+  patchable: false
+  stepback: false
+  # Same dependencies as "push" below
+  depends_on:
+  - name: package
+  - name: jsCore
+  - name: run_dbtest
+  - name: replica_sets_jscore_passthrough
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "fetch packages"
+    - func: "generate compile expansions"
+    - func: "apply compile expansions"
+    - func: "set up remote credentials"
+      vars:
+        aws_key_remote: ${repo_aws_key}
+        aws_secret_remote: ${repo_aws_secret}
+    - func: "set up notary client credentials"
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/packages_publish.sh"
+
+- name: push
+  tags: ["publish"]
+  patchable: false
+  depends_on:
+  - name: package
+  - name: jsCore
+  - name: run_dbtest
+  - name: replica_sets_jscore_passthrough
+  stepback: false
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "fetch packages"
+    - func: "fetch dist tarball"
+    # Fetch the shell
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: ${mongo_shell}
+        bucket: mciuploads
+        local_file: src/mongo-shell.tgz
+    # Fetch mongocryptd
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: ${mongo_cryptd}
+        bucket: mciuploads
+        local_file: src/mongo-cryptd.tgz
+        build_variants: *mongocryptd_variants
+    # Fetch the mongohouse binaries
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: ${mh_archive}
+        bucket: mciuploads
+        local_file: src/mh.tgz
+        build_variants: *mh_variants
+    # Fetch the sources (on relevant variants only)
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: ${project}/${build_variant}/${revision}/sources/mongo-src-${build_id}.${ext|tgz}
+        bucket: mciuploads
+        local_file: src/distsrc.${ext|tgz}
+        build_variants: [rhel70, windows]
+    - func: "generate compile expansions"
+    - func: "apply compile expansions"
+    - func: "fetch dist debugsymbols"
+    - func: "set up remote credentials"
+      vars:
+        aws_key_remote: ${repo_aws_key}
+        aws_secret_remote: ${repo_aws_secret}
+    - func: "f_expansions_write"
+    - func: "set up notary client credentials"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/notary_client_run.sh"
+
+    # Put the binaries tarball/zipfile
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}
+    # Put the shell tarball/zipfile
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}
+    # Put the cryptd tarball/zipfile
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}
+        build_variants: *mongocryptd_variants
+    # Put the mh tarball/zipfile
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mh-${push_name}-${push_arch}-${suffix}.${ext|tgz}
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mh-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}
+        build_variants: *mh_variants
+    # Put the source tarball
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-src-${src_suffix}.${ext|tar.gz}
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}
+        build_variants: [rhel70, windows]
+
+    # Put the debug symbols
+    # push directly to repo due to limitations in file size SERVER-63432
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        permissions: public-read
+        local_file: src/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}
+        bucket: ${push_bucket}
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}
+        optional: true
+
+    # Put the binaries tarball signature
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig
+
+    # Put the shell tarball signature
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig
+
+    # Put the cryptd tarball signature
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig
+        build_variants: *mongocryptd_variants
+
+    # Put the source tarball signature
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-src-${src_suffix}.${ext|tar.gz}.sig
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.sig
+        build_variants: [rhel70, windows]
+
+    # Put the debug symbols signature
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        permissions: public-read
+        local_file: src/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.sig
+        bucket: build-push-testing
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.sig
+        optional: true
+
+    # Put the signed MSI file
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        permissions: public-read
+        build_variants: ["enterprise-windows", "windows"]
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi
+        bucket: build-push-testing
+        content_type: application/x-msi
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi
+
+    # Put the binaries tarball sha1
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1
+        aws_key: ${aws_key}
+        permissions: public-read
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1
+
+    # Put the shell tarball sha1
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1
+        aws_key: ${aws_key}
+        permissions: public-read
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1
+
+    # Put the cryptd tarball sha1
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1
+        aws_key: ${aws_key}
+        permissions: public-read
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1
+        build_variants: *mongocryptd_variants
+
+    # Put the source tarball sha1
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-src-${src_suffix}.${ext|tar.gz}.sha1
+        aws_key: ${aws_key}
+        permissions: public-read
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.sha1
+        build_variants: [rhel70, windows]
+
+    # Put the debug symbols sha1
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        permissions: public-read
+        local_file: src/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.sha1
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.sha1
+        optional: true
+
+    # Push the signed MSI sha1
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        permissions: public-read
+        build_variants: ["enterprise-windows", "windows"]
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi.sha1
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi.sha1
+
+    # Put the binaries tarball sha256
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256
+        permissions: public-read
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256
+
+    # Put the shell tarball sha256
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256
+        permissions: public-read
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256
+
+    # Put the cryptd tarball sha256
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256
+        permissions: public-read
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256
+        build_variants: *mongocryptd_variants
+
+    # Put the source tarball sha256
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-src-${src_suffix}.${ext|tar.gz}.sha256
+        permissions: public-read
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.sha256
+        build_variants: [rhel70, windows]
+
+    # Put the debug symbols sha256
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.sha256
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.sha256
+        optional: true
+
+    # Put the signed MSI sha256
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        build_variants: ["enterprise-windows", "windows"]
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi.sha256
+        bucket: build-push-testing
+        permissions: public-read
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi.sha256
+        content_type: text/plain
+
+    # Put the binaries tarball md5
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5
+
+    # Put the shell tarball md5
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5
+
+    # Put the cryptd tarball md5
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5
+        build_variants: *mongocryptd_variants
+
+    # Put the source tarball md5
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-src-${src_suffix}.${ext|tar.gz}.md5
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.md5
+        build_variants: [rhel70, windows]
+
+    # Put the debug symbols md5
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.md5
+        bucket: build-push-testing
+        content_type: text/plain
+        permissions: public-read
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.md5
+        optional: true
+
+    # Put the signed MSI md5
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        build_variants: ["enterprise-windows", "windows"]
+        local_file: src/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi.md5
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi.md5
+
+    - command: s3Copy.copy
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        s3_copy_files:
+            #Binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}', 'bucket': '${push_bucket}'}}
+
+            #Shell
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}', 'bucket': '${push_bucket}'}}
+
+            #Cryptd
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}', 'bucket': '${push_bucket}'},
+               'build_variants': *mongocryptd_variants}
+
+            # MH
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mh-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mh-${push_name}-${push_arch}-${suffix}.${ext|tgz}', 'bucket': '${push_bucket}'},
+               'build_variants': *mh_variants}
+
+            #Source tarball
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}', 'bucket': 'build-push-testing'},
+               'destination': {'path': 'src/mongodb-src-${src_suffix}.${ext|tar.gz}', 'bucket': '${push_bucket}'},
+               'build_variants': ['rhel70', 'windows']}
+
+            #MSI (Windows only)
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi', 'bucket': '${push_bucket}'},
+               'build_variants': ['enterprise-windows', 'windows']}
+
+            #Binaries Signature
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig', 'bucket': '${push_bucket}'}}
+
+            #Shell Signature
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig', 'bucket': '${push_bucket}'}}
+
+            #Cryptd Signature
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig', 'bucket': '${push_bucket}'},
+               'build_variants': *mongocryptd_variants}
+
+            #Source tarball signature
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.sig', 'bucket': 'build-push-testing'},
+               'destination': {'path': 'src/mongodb-src-${src_suffix}.${ext|tar.gz}.sig', 'bucket': '${push_bucket}'},
+               'build_variants': ['rhel70', 'windows']}
+
+            #SHA1 for binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1', 'bucket': '${push_bucket}'}}
+
+            #SHA1 for shell
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1', 'bucket': '${push_bucket}'}}
+
+            #SHA1 for cryptd
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1', 'bucket': '${push_bucket}'},
+               'build_variants': *mongocryptd_variants}
+
+            #SHA1 for source tarball
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': 'src/mongodb-src-${src_suffix}.${ext|tar.gz}.sha1', 'bucket': '${push_bucket}'},
+               'build_variants': ['rhel70', 'windows']}
+
+            #SHA1 for MSI
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi.sha1', 'bucket': '${push_bucket}'},
+               'build_variants': ['enterprise-windows', 'windows']}
+
+            #SHA256 for binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256', 'bucket': '${push_bucket}'}}
+
+            #SHA256 for shell
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256', 'bucket': '${push_bucket}'}}
+
+            #SHA256 for cryptd
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256', 'bucket': '${push_bucket}'},
+               'build_variants': *mongocryptd_variants}
+
+            #SHA256 for source tarball
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': 'src/mongodb-src-${src_suffix}.${ext|tar.gz}.sha256', 'bucket': '${push_bucket}'},
+               'build_variants': ['rhel70', 'windows']}
+
+            #SHA256 for MSI files
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi.sha256', 'bucket': '${push_bucket}'},
+               'build_variants': ['enterprise-windows', 'windows']}
+
+            #MD5 for binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5', 'bucket': '${push_bucket}'}}
+
+            #MD5 for shell
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-shell-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-shell-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5', 'bucket': '${push_bucket}'}}
+
+            #MD5 for cryptd
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-cryptd-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5', 'bucket': '${push_bucket}'},
+               'build_variants': *mongocryptd_variants}
+
+            #MD5 for source tarball
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-src-${src_suffix}-${task_id}.${ext|tar.gz}.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': 'src/mongodb-src-${src_suffix}.${ext|tar.gz}.md5', 'bucket': '${push_bucket}'},
+               'build_variants': ['rhel70', 'windows']}
+
+            #MD5 for MSIs
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}-signed.msi.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}-signed.msi.md5', 'bucket': '${push_bucket}'},
+               'build_variants': ['enterprise-windows', 'windows']}
+
+    # Debug symbols are not created for all variants and the copy is optional.
+    - command: s3Copy.copy
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        optional: true
+        s3_copy_files:
+            #Debug Symbols temporarily removed - see SERVER-63432 - need to s3.push debugsymbols due to size limit
+            #Debug Symbols Signature
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.sig', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.sig', 'bucket': '${push_bucket}'}}
+
+            #SHA1 for debug symbols
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.sha1', 'bucket': '${push_bucket}'}}
+
+            #SHA256 for debugsymbols
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.sha256', 'bucket': '${push_bucket}'}}
+
+            #MD5 for debugsymbols
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}-${task_id}.${ext|tgz}.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-debugsymbols-${suffix}.${ext|tgz}.md5', 'bucket': '${push_bucket}'}}
+
+- name: csfle_push
+  tags: ["publish_csfle"]
+  patchable: false
+  stepback: false
+  depends_on:
+   - name: csfle_create_lib
+  commands:
+    - command: manifest.load
+    - func: "f_expansions_write"
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "get buildnumber"
+    - func: "f_expansions_write"
+    - func: "generate compile expansions"
+    - func: "apply compile expansions"
+    - func: "f_expansions_write"
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: ${project}/mongo_csfle/${build_variant}/${revision}/mongo_csfle_v1-${version}.${ext|tgz}
+        bucket: mciuploads
+        local_file: src/mongo_csfle_v1.${ext|tgz}
+    - func: "generate compile expansions"
+    - func: "apply compile expansions"
+    - func: "set up remote credentials"
+      vars:
+        aws_key_remote: ${repo_aws_key}
+        aws_secret_remote: ${repo_aws_secret}
+    - func: "f_expansions_write"
+    - func: "set up notary client credentials"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/notary_client_csfle_run.sh"
+    # Put the csfle tarball/zipfile
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}
+    # Put the csfle tarball signature
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sig
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        remote_file: ${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sig
+    # Put the csfle tarball sha1
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1
+        aws_key: ${aws_key}
+        permissions: public-read
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1
+    # Put the csfle tarball sha256
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256
+        permissions: public-read
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256
+    # Put the csfle tarball md5
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        local_file: src/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5
+        aws_key: ${aws_key}
+        bucket: build-push-testing
+        permissions: public-read
+        content_type: text/plain
+        remote_file: ${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5
+    - command: s3Copy.copy
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        s3_copy_files:
+            #Binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}', 'bucket': '${push_bucket}'}}
+            #SHA1 for binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha1', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha1', 'bucket': '${push_bucket}'}}
+            #SHA256 for binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.sha256', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.sha256', 'bucket': '${push_bucket}'}}
+            #MD5 for binaries
+            - {'source': {'path': '${push_path}-STAGE/${push_name}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}.md5', 'bucket': 'build-push-testing'},
+               'destination': {'path': '${push_path}/mongo_csfle_v1-${push_name}-${push_arch}-${suffix}.${ext|tgz}.md5', 'bucket': '${push_bucket}'}}
+
+- <<: *task_template
+  name: search
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: search_auth
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: search_ssl
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+    vars:
+      resmoke_jobs_max: 1
+
+- <<: *task_template
+  name: cqf
+  tags: []
+  commands:
+    - func: "do setup"
+    - func: "run tests"
+
+- <<: *task_template
+  name: cqf_parallel
+  tags: []
+  commands:
+    - func: "do setup"
+    - func: "run tests"
+
+- name: shared_scons_cache_pruning
+  tags: []
+  exec_timeout_secs: 7200 # 2 hour timeout for the task overall
+  depends_on: []
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - *set_up_venv
+  - func: "shared scons cache pruning"
+
+- name: win_shared_scons_cache_pruning
+  tags: []
+  exec_timeout_secs: 21600 # 2 hour timeout for the task overall
+  depends_on: []
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - *set_up_venv
+  - func: "set up win mount script"
+  - func: "shared scons cache pruning"
+
+- name: validate_commit_message
+  tags: []
+  exec_timeout_secs: 600 # 10 minute timeout
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - *f_expansions_write
+  - *kill_processes
+  - *cleanup_environment
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - command: subprocess.exec
+    type: test
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/commit_message_validate.sh"
+      env:
+        JIRA_AUTH_ACCESS_TOKEN: ${jira_auth_access_token}
+        JIRA_AUTH_ACCESS_TOKEN_SECRET: ${jira_auth_access_token_secret}
+        JIRA_AUTH_CONSUMER_KEY: ${jira_auth_consumer_key}
+        JIRA_AUTH_KEY_CERT: ${jira_auth_key_cert}
+
+- name: check_for_todos
+  tags: []
+  exec_timeout_secs: 600 # 10 minute timeout
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - func: "configure evergreen api credentials"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/todos_check.sh"
+
+- <<: *task_template
+  name: mqlrun
+  tags: []
+  commands:
+  - func: "do setup"
+  - func: "run tests"
+
+- name: check_feature_flag_tags
+  tags: []
+  patch_only: true
+  commands:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - *f_expansions_write
+    - *kill_processes
+    - *cleanup_environment
+    - func: "set up venv"
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/feature_flag_tags_check.sh"
+
+- name: antithesis_image_build
+  tags: ["antithesis"]
+  # this is not patchable to avoid hitting the docker registry excessively.
+  # When iterating on this task, feel free to make this patchable for
+  # testing purposes. Your image changes will be pushed with the
+  # evergreen-patch tag, so as to not clobber the waterfall. Use the
+  # antithesis_image_tag build parameter to override this if required.
+  patchable: false
+  depends_on:
+  - name: archive_dist_test_debug
+  commands:
+  - *f_expansions_write
+  - func: "git get project no modules"
+  - func: "f_expansions_write"
+  - func: "kill processes"
+  - func: "cleanup environment"
+  - func: "set up venv"
+  - command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/antithesis_last_push.txt
+      local_file: antithesis_last_push.txt
+      bucket: mciuploads
+  - func: "do setup"
+  - command: s3.get
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${mongo_debugsymbols}
+      bucket: mciuploads
+      local_file: src/mongo-debugsymbols.tgz
+  - command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "./src/evergreen/antithesis_image_build.sh"
+  - command: s3.put
+    params:
+      optional: true
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: antithesis_next_push.txt
+      remote_file: ${project}/${build_variant}/antithesis_last_push.txt
+      bucket: mciuploads
+      permissions: private
+      content_type: text/plain
+      display_name: Last Push Date (seconds since epoch)
+
+- name: generate_buildid_to_debug_symbols_mapping
+  tags: ["symbolizer"]
+  stepback: false
+  patchable: true
+  depends_on:
+    - archive_dist_test_debug
+  commands:
+    - *f_expansions_write
+    - func: "do setup"
+    - func: "configure evergreen api credentials"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "./src/evergreen/generate_buildid_debug_symbols_mapping.sh"
+
+#######################################
+#             Task Groups             #
+#######################################
+task_groups:
+- <<: *compile_task_group_template
+  name: compile_dist_test_TG
+  tasks:
+  - compile_dist_test
+
+- <<: *compile_task_group_template
+  name: compile_and_archive_dist_test_TG
+  tasks:
+  - compile_dist_test
+  - archive_dist_test
+  - archive_dist_test_debug
+
+- <<: *compile_task_group_template
+  name: compile_and_archive_dist_test_then_package_TG
+  tasks:
+  - compile_dist_test
+  - archive_dist_test
+  - archive_dist_test_debug
+  - package
+
+- <<: *compile_task_group_template
+  name: compile_ninja_next_TG
+  tasks:
+  - compile_ninja_next
+
+- <<: *compile_task_group_template
+  name: compile_build_tools_next_TG
+  tasks:
+  - compile_build_tools_next
+
+- <<: *compile_task_group_template
+  name: libdeps_graph_linting_TG
+  tasks:
+  - libdeps_graph_linting
+
+- <<: *compile_task_group_template
+  name: compile_ninja_TG
+  tasks:
+  - compile_ninja
+  teardown_task:
+    - command: s3.put
+      params:
+        optional: true
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/all.build.ninja
+        remote_file: ${project}/${build_variant}/${revision}/artifacts/all.${build_id}.build.ninja
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/plain
+        display_name: build.ninja
+
+- <<: *compile_task_group_template
+  name: server_discovery_and_monitoring_json_test_TG
+  tasks:
+  - server_discovery_and_monitoring_json_test
+
+- <<: *compile_task_group_template
+  name: server_selection_json_test_TG
+  tasks:
+  - server_selection_json_test
+
+- <<: *compile_task_group_template
+  name: compile_run_and_archive_dbtest_TG
+  tasks:
+  - compile_dbtest
+  - run_dbtest
+  - archive_dbtest
+
+- <<: *compile_task_group_template
+  name: compile_archive_and_run_libfuzzertests_TG
+  tasks:
+  - compile_and_archive_libfuzzertests
+  - fetch_and_run_libfuzzertests
+
+- <<: *compile_task_group_template
+  name: compile_test_and_package_serial_TG
+  tasks:
+  - compile_dist_test
+  - archive_dist_test
+  - archive_dist_test_debug
+  - compile_unittests
+  - run_unittests
+  - compile_dbtest
+  - run_dbtest
+  - archive_dbtest
+  - compile_all
+  - package
+
+- <<: *compile_task_group_template
+  name: compile_and_test_TG
+  tasks:
+  - compile_dist_test
+  - compile_unittests
+  - run_unittests
+  - compile_dbtest
+  - run_dbtest
+  - compile_all
+
+# These `parallel` task groups are only appropriate for builders that
+# use --link-model=dynamic, and have scons_cache_scope: shared and
+# scons_cache_mode: all. Such builders are able to share all build
+# artifacts, and therefore will not repeatedly re-link the same
+# code. In that mode, it makes sense to run all of these tasks
+# concurrently, since they will share state across machines and can
+# complete faster than running them serially. We keep them in task
+# groups so that if they do run on the same machine, they can avoid the
+# cost of re-running the setup tasks.
+- <<: *compile_task_group_template
+  name: compile_test_and_package_parallel_core_stream_TG
+  tasks:
+  - compile_dist_test
+  - determine_patch_tests
+  - archive_dist_test
+  - archive_dist_test_debug
+  - compile_all
+  - package
+
+- <<: *compile_task_group_template
+  name: compile_test_and_package_parallel_unittest_stream_TG
+  tasks:
+  - compile_unittests
+  - run_unittests
+
+#- <<: *compile_task_group_template
+#  name: compile_test_and_package_parallel_unittest_stream_with_recording_TG
+#  tasks:
+#    - compile_unittests_for_recorded_unittest
+#    - run_unittests_with_recording
+
+- <<: *compile_task_group_template
+  name: compile_test_and_package_parallel_dbtest_stream_TG
+  tasks:
+  - compile_dbtest
+  - run_dbtest
+  - archive_dbtest
+
+- name: clang_tidy_TG
+  setup_group_can_fail_task: true
+  setup_group:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "configure evergreen api credentials"
+    - func: "get buildnumber"
+    - func: "f_expansions_write"
+    - func: "set up credentials"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+  teardown_group:
+    - func: "f_expansions_write"
+    - func: "umount shared scons directory"
+    - func: "cleanup environment"
+  setup_task:
+    - func: "apply compile expansions"
+    - func: "f_expansions_write"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+  teardown_task:
+  tasks:
+  - clang_tidy
+
+- name: visibility_test_TG
+  setup_group_can_fail_task: true
+  max_hosts: 1
+  setup_group:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "get buildnumber"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "set up credentials"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+  teardown_group:
+    - func: "umount shared scons directory"
+  setup_task:
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "apply compile expansions"
+    - func: "f_expansions_write"
+  teardown_task:
+      - func: "attach scons logs"
+  tasks:
+  - compile_visibility_test
+
+- name: embedded_sdk_build_and_test
+  setup_group_can_fail_task: true
+  max_hosts: 1
+  setup_group:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "get buildnumber"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "set up credentials"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+  teardown_group:
+    - func: "umount shared scons directory"
+  setup_task:
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "apply compile expansions"
+    - func: "f_expansions_write"
+  teardown_task:
+      - func: "attach scons logs"
+  tasks:
+  - "embedded_sdk_build_cdriver"
+  - "embedded_sdk_install_dev"
+  - "embedded_sdk_s3_put"
+  - "embedded_sdk_install_tests"
+  - "embedded_sdk_tests_s3_put"
+  - "embedded_sdk_run_tests"
+  - "embedded_sdk_s3_put_latest"
+  - "embedded_sdk_tests_s3_put_latest"
+
+- <<: *stitch_support_task_group_template
+  name: stitch_support_lib_build_and_archive
+  tags: ["stitch"]
+  tasks:
+    - "stitch_support_create_lib"
+- <<: *stitch_support_task_group_template
+  name: stitch_support_lib_build_and_test
+  tags: ["stitch"]
+  max_hosts: 1
+  tasks:
+    - "stitch_support_install_tests"
+    - "stitch_support_run_tests"
+
+- name: csfle_build
+  setup_task:
+    - func: "f_expansions_write"
+    - func: "apply compile expansions"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+  teardown_task:
+  - func: "attach scons logs"
+  setup_group_can_fail_task: true
+  setup_group:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "get buildnumber"
+    - func: "f_expansions_write"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+  teardown_group:
+    - func: "umount shared scons directory"
+  tags: ["csfle"]
+  max_hosts: 1
+  tasks:
+    - "csfle_create_lib"
+
+- name: csfle_build_debug_and_test
+  setup_task:
+    - func: "f_expansions_write"
+    - func: "apply compile expansions"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+  teardown_task:
+  - func: "attach scons logs"
+  setup_group_can_fail_task: true
+  setup_group:
+    - command: manifest.load
+    - func: "git get project and add git tag"
+    - func: "set task expansion macros"
+    - func: "f_expansions_write"
+    - func: "kill processes"
+    - func: "cleanup environment"
+    - func: "set up venv"
+    - func: "upload pip requirements"
+    - func: "get buildnumber"
+    - func: "f_expansions_write"
+    - func: "set up win mount script"
+    - func: "generate compile expansions"
+  teardown_group:
+    - func: "umount shared scons directory"
+  max_hosts: 1
+  tasks:
+    - "csfle_create_debug_lib"
+    - "csfle_install_tests"
+    - "csfle_run_tests"
+
+#######################################
+#               Modules               #
+#######################################
+# if a module is added and to be added to the manifest
+# be sure to add the module to git.get_project revisions parameter
+modules:
+- name: enterprise
+  repo: git@github.com:10gen/mongo-enterprise-modules.git
+  prefix: src/mongo/db/modules
+  branch: master
+
+- name: wtdevelop
+  repo: git@github.com:wiredtiger/wiredtiger.git
+  prefix: src/third_party
+  branch: develop
+
+#######################################
+#            Buildvariants            #
+#######################################
+
+buildvariants:
+
+###########################################
+#         Linux buildvariants             #
+###########################################
+
+- &linux-64-debug-required-template
+  name: linux-64-debug-required
+  display_name: "! Shared Library Linux DEBUG"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  run_on:
+  - rhel80-medium
+  expansions:
+    resmoke_jobs_factor: 0.5  # Avoid starting too many mongod's
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --enable-free-mon=on --enable-http-client=on --link-model=dynamic
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    test_flags: --excludeWithAnyTags=requires_http_client
+    target_resmoke_time: 15
+    max_sub_suites: 5
+    num_scons_link_jobs_available: 0.99
+    large_distro_name: rhel80-medium
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+  - name: .aggregation !.encrypt
+  - name: .auth !.audit !.multiversion
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams !.secondary_reads
+  - name: .clustered_collections
+  - name: .misc_js
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: libunwind_tests
+  - name: .multi_shard
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: .ocsp
+  - name: .read_write_concern
+  - name: .replica_sets !.encrypt !.ignore_non_generated_replica_sets_jscore_passthrough !.fcbis
+  - name: replica_sets_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+  - name: .retry
+  - name: .read_only
+  - name: session_jscore_passthrough
+  - name: sharded_multi_stmt_txn_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: sharding_gen
+  - name: .stitch
+  - name: server_discovery_and_monitoring_json_test_TG
+    distros:
+    - rhel80-large
+  - name: server_selection_json_test_TG
+    distros:
+    - rhel80-large
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- <<: *linux-64-debug-required-template
+  name: linux-64-debug-wtdevelop
+  display_name: "~ Linux DEBUG WiredTiger develop"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - wtdevelop
+  expansions:
+    use_wt_develop: true
+    resmoke_jobs_factor: 0.5  # Avoid starting too many mongod's
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --enable-free-mon=on --enable-http-client=on
+    scons_cache_mode: nolinked
+    test_flags: --excludeWithAnyTags=requires_http_client
+
+- name: linux-64-duroff
+  display_name: Linux (No Journal)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel80-small
+  expansions: &linux-64-required-duroff-expansions
+    compile_flags: -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --enable-free-mon=off --enable-http-client=off
+    multiversion_platform: rhel80
+    multiversion_edition: targeted
+    # Running WiredTiger with --nojournal in a replica set is no longer supported, so this variant
+    # does not include replica set tests. Since transactions are only supported on replica sets, we
+    # exclude those tests as well.
+    test_flags: --nojournal --excludeWithAnyTags=requires_journaling,requires_replication,requires_sharding,uses_transactions,requires_http_client
+    scons_cache_scope: shared
+    large_distro_name: rhel80-medium
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: aggregation_auth
+  - name: auth_gen
+  - name: .misc_js !.sharded
+  - name: concurrency_gen
+  - name: concurrency_simultaneous_gen
+  - name: disk_wiredtiger
+  - name: failpoints_auth
+  - name: .jscore .common !.sharding !.decimal !.txns
+  - name: .jstestfuzz .common !.sharding !.repl
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: ubuntu1804
+  display_name: Ubuntu 18.04
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1804-test
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-ubuntu1804
+    compile_flags: --ssl --ocsp-stapling=off MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: targeted
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: ubuntu1804
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jepsen
+    distros:
+    - ubuntu1804-build
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: .powercycle
+  - name: replica_sets_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .sharding .txns
+  - name: sharding_gen
+  - name: sharding_jscore_passthrough
+  - name: watchdog_wiredtiger
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu1804-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-ubuntu1804-64
+  display_name: Enterprise Ubuntu 18.04
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-test
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-ubuntu1804
+    compile_flags: --ssl --ocsp-stapling=off MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: ubuntu1804
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: compile_build_tools_next_TG
+    distros:
+    - ubuntu1804-build
+  - name: libdeps_graph_linting_TG
+    distros:
+      - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .csfle
+  - name: .publish_csfle
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.aggregation !.replica_sets !.sharding !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jepsen
+    distros:
+    - ubuntu1804-build
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_auth
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: .multiversion_fuzzer
+  - name: .multiversion_passthrough
+  - name: .ocsp
+  - name: .random_multiversion_ds
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .watchdog
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu1804-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: tla-plus
+  display_name: TLA+
+  run_on:
+  - ubuntu1804-build
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  stepback: false
+  expansions:
+    timeout_secs: 345600 # 4 days
+  tasks:
+  - name: tla_plus
+
+- name: enterprise-ubuntu1804-64-ninja
+  display_name: "Ninja Build: Enterprise Ubuntu 18.04"
+  cron: "0 0 * * *" # Every day starting at midnight
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-test
+  stepback: false
+  expansions:
+    compile_flags: --ssl --ocsp-stapling=off MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    repo_edition: enterprise
+    has_packages: false
+  tasks:
+  - name: compile_ninja_next_TG
+    distros:
+    - ubuntu1804-build
+  - name: compile_ninja_TG
+    distros:
+    - ubuntu1804-build
+
+
+- name: enterprise-ubuntu1804-arm64
+  display_name: Enterprise Ubuntu 18.04 arm64
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-arm64-build
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: aarch64-enterprise-ubuntu1804
+    compile_flags: --ssl --ocsp-stapling=off MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    resmoke_jobs_max: 4 # Avoid starting too many mongod's on ARM test servers
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: arm64
+    packager_distro: ubuntu1804
+    repo_edition: enterprise
+    multiversion_platform: ubuntu1804
+    multiversion_architecture: arm64
+    multiversion_architecture_42_or_later: aarch64
+    multiversion_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: aggregation
+  - name: aggregation_wildcard_fuzzer_gen
+  - name: .auth !.audit !.multiversion !.jscore
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: fle
+  - name: .jscore .common !.auth
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: sharding_gen
+  - name: sharding_jscore_passthrough
+  - name: .ssl
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+    distros:
+    - ubuntu1804-test
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu1804-test
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: ubuntu1804-arm64
+  display_name: Ubuntu 18.04 arm64
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1804-arm64-build
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: aarch64-ubuntu1804
+    compile_flags: --ssl --ocsp-stapling=off MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    resmoke_jobs_max: 8 # Avoid starting too many mongod's on ARM test servers
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: arm64
+    packager_distro: ubuntu1804
+    repo_edition: org
+    multiversion_platform: ubuntu1804
+    multiversion_architecture: arm64
+    multiversion_architecture_42_or_later: aarch64
+    multiversion_edition: targeted
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: free_monitoring
+  - name: jsCore
+  - name: replica_sets_jscore_passthrough
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu1804-test
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: ubuntu2004
+  display_name: Ubuntu 20.04
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu2004-small
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-ubuntu2004
+    compile_flags: --ssl MONGO_DISTMOD=ubuntu2004 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu2004
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: ubuntu2004
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: ubuntu2004-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu2004-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common !.multiversion # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  # - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .sharding .txns
+  - name: sharding_gen
+  - name: sharding_jscore_passthrough
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu2004-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-ubuntu2004-64
+  display_name: Enterprise Ubuntu 20.04
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu2004-small
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-ubuntu2004
+    compile_flags: --ssl MONGO_DISTMOD=ubuntu2004 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: ubuntu2004
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: ubuntu2004
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: ubuntu2004-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu2004-large
+  - name: build_variant_gen
+  - name: .csfle
+  - name: .publish_csfle
+#  - name: .aggfuzzer .common !.multiversion # Disabled for FCV 5.3
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.aggregation !.replica_sets !.sharding !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_auth
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: .ocsp
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu2004-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-ubuntu2004-arm64
+  display_name: Enterprise Ubuntu 20.04 arm64
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu2004-arm64-large
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: aarch64-enterprise-ubuntu2004
+    compile_flags: --ssl MONGO_DISTMOD=ubuntu2004 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    resmoke_jobs_max: 4 # Avoid starting too many mongod's on ARM test servers
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: arm64
+    packager_distro: ubuntu2004
+    repo_edition: enterprise
+    multiversion_platform: ubuntu2004
+    multiversion_architecture: arm64
+    multiversion_architecture_42_or_later: aarch64
+    multiversion_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: aggregation
+  - name: aggregation_wildcard_fuzzer_gen
+  - name: .auth !.audit !.multiversion !.jscore
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: fle
+  - name: .jscore .common !.auth
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: sharding_gen
+  - name: sharding_jscore_passthrough
+  - name: .ssl
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu2004-test
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: ubuntu2004-arm64
+  display_name: Ubuntu 20.04 arm64
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu2004-arm64-large
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: aarch64-ubuntu2004
+    compile_flags: --ssl MONGO_DISTMOD=ubuntu2004 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    resmoke_jobs_max: 8 # Avoid starting too many mongod's on ARM test servers
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: arm64
+    packager_distro: ubuntu2004
+    repo_edition: org
+    multiversion_platform: ubuntu2004
+    multiversion_architecture: arm64
+    multiversion_architecture_42_or_later: aarch64
+    multiversion_edition: targeted
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: free_monitoring
+  - name: jsCore
+  - name: replica_sets_jscore_passthrough
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - ubuntu2004-test
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- &enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-dynamic-v4gcc-debug-experimental
+  display_name: "~ Shared Library Enterprise RHEL 8.0 v4 Toolchain GCC DEBUG"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions: &enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic --variables-files=etc/scons/mongodbtoolchain_testing_gcc.vars
+    has_packages: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    large_distro_name: rhel80-medium
+    num_scons_link_jobs_available: 0.99
+  tasks: &enterprise-rhel80-dynamic-v4gcc-debug-experimental-tasks
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: build_variant_gen
+  - name: test_api_version_compatibility
+#  - name: .aggfuzzer !.multiversion # Disabled for FCV 5.3
+  - name: .aggregation !.multiversion
+  - name: audit
+  - name: .auth !.multiversion
+  - name: .causally_consistent !.sharding
+  - name: .change_streams !.multiversion
+  - name: .change_stream_fuzzer !.multiversion
+  - name: .misc_js !.multiversion
+  - name: .concurrency !.large !.ubsan !.no_txns !.debug_only !.multiversion
+  - name: .concurrency .large !.ubsan !.no_txns !.debug_only !.multiversion
+    distros:
+    - rhel80-xlarge
+  - name: disk_wiredtiger
+  - name: .encrypt !.multiversion
+  - name: idl_tests
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.multiversion
+    distros:
+    - rhel80-xlarge
+  - name: jsCore
+    distros:
+    - rhel80-xlarge
+  - name: .jscore .common !jsCore !.multiversion
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .jstestfuzz !.flow_control  !.multiversion # Flow control jstestfuzz take longer.
+  - name: libunwind_tests
+  - name: mqlrun
+  - name: .multi_shard !.multiversion
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: .query_fuzzer !.multiversion
+  - name: .read_write_concern .large !.multiversion
+    distros:
+    - rhel80-xlarge
+  - name: .read_write_concern !.large !.multiversion
+  - name: .replica_sets !.encrypt !.auth !.multiversion
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_api_version_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: .read_only !.multiversion
+  - name: .rollbackfuzzer !.multiversion
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt !.multiversion
+  - name: sharding_api_version_jscore_passthrough_gen
+  - name: .sharding .txns !.multiversion
+  - name: .sharding .common !.multiversion
+  - name: snmp
+  - name: .stitch
+  - name: secondary_reads_passthrough_gen
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: .serverless !.multiversion
+    distros:
+      - rhel80-xlarge
+  - name: server_selection_json_test_TG
+    distros:
+      - rhel80-xlarge
+
+- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-dynamic-v4clang-debug-experimental
+  display_name: "~ Shared Library Enterprise RHEL 8.0 v4 Toolchain Clang DEBUG"
+  expansions:
+    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic --variables-files=etc/scons/mongodbtoolchain_testing_clang.vars
+
+- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-dynamic-v4gcc-cxx20-debug-experimental
+  display_name: "~ Shared Library Enterprise RHEL 8.0 v4 Toolchain GCC C++20 DEBUG"
+  expansions:
+    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic --variables-files=etc/scons/mongodbtoolchain_testing_gcc.vars --cxx-std=20
+
+- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-dynamic-v4clang-cxx20-debug-experimental
+  display_name: "~ Shared Library Enterprise RHEL 8.0 v4 Toolchain Clang C++20 DEBUG"
+  expansions:
+    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic --variables-files=etc/scons/mongodbtoolchain_testing_clang.vars --cxx-std=20
+
+- name: enterprise-rhel-80-64-bit-coverage-v4gcc
+  display_name: "~ Enterprise RHEL 8.0 DEBUG Code Coverage (v4 Toolchain)"
+  modules:
+    - enterprise
+  run_on:
+    - rhel80-medium
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    test_flags: --excludeWithAnyTags=resource_intensive --excludeWithAnyTags=incompatible_with_gcov
+    compile_flags: --dbg=on --gcov --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v4_gcc.vars
+    large_distro_name: rhel80-medium
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.5  # Avoid starting too many mongod's
+    # The gcov instrumentation saves the path the .gcno files were created in as the default path
+    # for the .gcda files. In Evergreen the path will start with /data/mci/[Hashed ID]/src/... where
+    # the hashed ID is unique per task run. GCOV_PREFIX_STRIP is the number of directory levels to
+    # strip from the top of the default path before appending to the GCOV_PREFIX (if any).
+    gcov_environment: GCOV_PREFIX=$(pwd) GCOV_PREFIX_STRIP=4
+    # Mixing --cache and --gcov doesn't work correctly yet. See SERVER-11084
+    exec_timeout_secs: 32400 # 9 hour timeout
+    timeout_secs: 18000 # 5 hour idle timeout
+    use_scons_cache: false
+  tasks: &enterprise-rhel-80-64-bit-coverage-tasks
+    - name: compile_test_and_package_serial_TG
+      distros:
+      - rhel80-large
+    - name: build_variant_gen
+    # to reduce the overall size of the generated configuration, most of the
+    # tasks we would normally include have been disabled. See revert of
+    # SERVER-60832
+#    - name: .aggfuzzer # Disabled for FCV 5.3
+    #- name: .aggregation !.unwind
+    #- name: audit
+    #- name: .auth
+    #- name: causally_consistent_jscore_txns_passthrough
+    #- name: .change_streams
+    #- name: .misc_js # serial_run needs extra memory
+    #  distros:
+    #  - rhel80-large
+    #- name: .concurrency !.ubsan !.no_txns !.stepdowns !.kill_terminate !.disabled_on_code_coverage
+    #- name: disk_wiredtiger
+    #- name: .encrypt
+    #- name: initial_sync_fuzzer_gen
+    #- name: .integration !.audit
+    - name: .jscore .common
+    #- name: jsCore_txns_large_txns_format
+    #- name: jsCore_minimum_batch_size
+    #- name: libunwind_tests
+    #- name: .logical_session_cache .one_sec
+    #- name: .multi_shard .common
+    #- name: multiversion_gen
+    #- name: .multiversion_fuzzer
+    #- name: .multiversion_passthrough
+    #- name: .query_fuzzer
+    #- name: .random_multiversion_ds
+    #- name: .read_write_concern
+    - name: .replica_sets !.ignore_non_generated_replica_sets_jscore_passthrough
+    - name: replica_sets_jscore_passthrough_gen
+    #- name: .read_only
+    #- name: .rollbackfuzzer
+    #- name: retryable_writes_jscore_passthrough_gen
+    #- name: sasl
+    #- name: search
+    #- name: search_auth
+    #- name: search_ssl
+    #- name: secondary_reads_passthrough_gen
+    #- name: session_jscore_passthrough
+    #- name: .sharding .jscore !.wo_snapshot
+    - name: .sharding .common
+    #- name: snmp
+    #- name: update_fuzzer_gen
+
+- name: enterprise-rhel-80-64-bit-bson-column
+  display_name: "~ Shared Library Enterprise RHEL 8.0 (BSONColumn validate)"
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    has_packages: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    jstestfuzz_num_generated_files: 40
+    jstestfuzz_concurrent_num_files: 10
+    target_resmoke_time: 10
+    max_sub_suites: 5
+    large_distro_name: rhel80-medium
+    burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem linux-64-duroff enterprise-rhel-80-64-bit-multiversion
+    num_scons_link_jobs_available: 0.99
+    test_flags: >-
+      --mongodSetParameters="{roundtripBsonColumnOnValidate: true}"
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-xlarge
+#  - name: compile_test_and_package_parallel_unittest_stream_with_recording_TG
+#    distros:
+#      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation
+  - name: audit
+  - name: unittest_shell_hang_analyzer_gen
+  - name: .causally_consistent !.sharding
+  - name: .change_streams
+  - name: .change_stream_fuzzer
+  - name: .misc_js
+  - name: .concurrency !.large !.ubsan !.no_txns !.debug_only
+    distros:
+    - rhel80-medium
+  - name: config_fuzzer_concurrency
+  - name: config_fuzzer_simulate_crash_concurrency_replication
+    distros:
+    - rhel80-large
+  - name: config_fuzzer_concurrency_replication
+    distros:
+    - rhel80-large
+  - name: config_fuzzer_jsCore
+  - name: config_fuzzer_replica_sets_jscore_passthrough
+    distros:
+    - rhel80-large
+  - name: disk_wiredtiger
+  - name: idl_tests
+  - name: initial_sync_fuzzer_gen
+  - name: .integration
+    distros:
+    - rhel80-medium
+  - name: jsCore
+    distros:
+    - rhel80-xlarge
+  - name: .jscore .common !jsCore
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .jstestfuzz !.flow_control  # Flow control jstestfuzz take longer.
+  - name: libunwind_tests
+  - name: mqlrun
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: .query_fuzzer
+  - name: .read_write_concern .large
+    distros:
+    - rhel80-medium
+  - name: .read_write_concern !.large
+  - name: .replica_sets !.encrypt !.auth
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_api_version_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: session_jscore_passthrough
+  - name: snmp
+  - name: .stitch
+  - name: .updatefuzzer
+  - name: secondary_reads_passthrough_gen
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+    distros:
+      - rhel80-xlarge
+
+#- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+#  name: enterprise-rhel80-dynamic-v4gcc-cxx20-debug-pm-1328-experimental
+#  display_name: "~ Shared Library Enterprise RHEL 8.0 v4 Toolchain GCC C++20 DEBUG + PM-1328"
+#  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+#  expansions:
+#    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+#    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic --variables-files=etc/scons/mongodbtoolchain_testing_gcc.vars --cxx-std=20 --experimental-optimization=* --experimental-runtime-hardening=* --disable-warnings-as-errors
+
+- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-dynamic-v4clang-cxx20-debug-pm-1328-experimental
+  display_name: "~ Shared Library Enterprise RHEL 8.0 v4 Toolchain Clang C++20 DEBUG + PM-1328"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  expansions:
+    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic --variables-files=etc/scons/mongodbtoolchain_testing_clang.vars --cxx-std=20 --experimental-optimization=* --experimental-runtime-hardening=*
+
+- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-v4gcc-cxx20-pm-1328-experimental
+  display_name: "~ Enterprise RHEL 8.0 v4 Toolchain GCC C++20 + PM-1328"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  expansions:
+    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    compile_flags: --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_testing_gcc.vars --cxx-std=20 --experimental-optimization=* --experimental-runtime-hardening=* --disable-warnings-as-errors
+
+- <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-template
+  name: enterprise-rhel80-v4clang-cxx20-pm-1328-experimental
+  display_name: "~ Enterprise RHEL 8.0 v4 Toolchain Clang C++20 + PM-1328"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  expansions:
+    <<: *enterprise-rhel80-dynamic-v4gcc-debug-experimental-expansions
+    compile_flags: --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_testing_clang.vars --cxx-std=20 --experimental-optimization=* --experimental-runtime-hardening=*
+
+- name: enterprise-linux-64-amazon-ami
+  display_name: "Enterprise Amazon Linux"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - amazon1-2018-test
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-amzn64
+    compile_flags: --ssl MONGO_DISTMOD=amzn64 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    test_flags: --excludeWithAnyTags=incompatible_with_amazon_linux
+    multiversion_platform: amzn64
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: amazon
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    virtualenv: /opt/mongodbtoolchain/v3/bin/virtualenv
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - amazon1-2018-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.multiversion
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.aggregation
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: noPassthrough_gen
+  - name: noPassthroughWithMongod_gen
+  - name: .powercycle
+  - name: .replica_sets .common
+  - name: sasl
+  - name: serial_run
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .txns
+  - name: slow1_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - amazon1-2018-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: amazon
+  display_name: Amazon Linux
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - amazon1-2018-test
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-amazon
+    compile_flags: --ssl MONGO_DISTMOD=amazon -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    test_flags: --excludeWithAnyTags=incompatible_with_amazon_linux
+    multiversion_platform: amazon
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: amazon
+    repo_edition: org
+    scons_cache_scope: shared
+    virtualenv: /opt/mongodbtoolchain/v3/bin/virtualenv
+    large_distro_name: amazon1-2018-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - amazon1-2018-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+  - name: .sharding .txns
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - amazon1-2018-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-amazon2
+  display_name: "Enterprise Amazon Linux 2"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - amazon2-test
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    # TODO BUILD-13887 should fix uses_pykmip incompatibility.
+    test_flags: >-
+      --excludeWithAnyTags=SERVER-34286,incompatible_with_amazon_linux,uses_pykmip
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-amazon2
+    compile_flags: --ssl MONGO_DISTMOD=amazon2 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: amazon2
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: amazon2
+    repo_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - amazon2-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: audit
+  - name: .auth !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.aggregation
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: noPassthrough_gen
+  - name: noPassthroughWithMongod_gen
+  - name: .replica_sets .common
+  - name: sasl
+  - name: serial_run
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .txns !.csrs
+  - name: slow1_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - amazon2-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: amazon2
+  display_name: Amazon Linux 2
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - amazon2-test
+  expansions:
+    test_flags: >-
+      --excludeWithAnyTags=SERVER-34286,incompatible_with_amazon_linux
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-amazon2
+    compile_flags: --ssl MONGO_DISTMOD=amazon2 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: amazon2
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: amazon2
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: amazon2-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - amazon2-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+  - name: .sharding .txns
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - amazon2-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-amazon2-arm64
+  display_name: "Enterprise Amazon Linux 2 arm64"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - amazon2-arm64-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: aarch64-enterprise-amazon2
+    compile_flags: --ssl MONGO_DISTMOD=amazon2 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    # TODO BUILD-13887 should fix uses_pykmip incompatibility.
+    test_flags: --excludeWithAnyTags=incompatible_with_amazon_linux,requires_ldap_pool,uses_pykmip
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: aarch64
+    packager_distro: amazon2
+    repo_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - amazon2-arm64-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer !.multiversion # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.sharding !.replica_sets !.aggregation !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .replica_sets .multi_oplog
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: sharding_auth_audit_gen
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - rhel80-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: amazon2-arm64
+  display_name: Amazon Linux 2 arm64
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - amazon2-arm64-small
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: aarch64-amazon2
+    compile_flags: --ssl MONGO_DISTMOD=amazon2 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    test_flags: --excludeWithAnyTags=incompatible_with_amazon_linux
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: aarch64
+    packager_distro: amazon2
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: amazon2-arm64-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - amazon2-arm64-large
+  - name: build_variant_gen
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+    distros:
+      - amazon2-arm64-large
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs !.multiversion
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - rhel80-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: stm-daily-cron
+  modules:
+  - enterprise
+  display_name: "~ STM Daily Cron"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel80-small
+  expansions:
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+  stepback: false
+  tasks:
+  - name: lint_fuzzer_sanity_all
+  - name: powercycle_sentinel
+  - name: powercycle_smoke_skip_compile_gen
+
+- name: security-daily-cron
+  modules:
+  - enterprise
+  display_name: "~ Security Daily Cron"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel80-small
+  stepback: false
+  tasks:
+  - name: blackduck_scanner
+
+###########################################
+#         Windows buildvariants           #
+###########################################
+
+- name: windows-debug-suggested
+  display_name: "* Windows DEBUG"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  run_on:
+  - windows-vsCurrent-small
+  expansions:
+    exe: ".exe"
+    content_type: application/zip
+    compile_flags: --dbg=on --opt=on --win-version-min=win10 -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") MONGO_DISTMOD=windows
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    multiversion_platform: windows
+    multiversion_edition: enterprise
+    large_distro_name: windows-vsCurrent-large
+    test_flags: &windows_common_test_excludes --excludeWithAnyTags=incompatible_with_windows_tls
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - windows-vsCurrent-xlarge
+  - name: compile_build_tools_next_TG
+    distros:
+    - windows-vsCurrent-xlarge
+  - name: build_variant_gen
+  - name: .aggregation !.auth !.encrypt
+  - name: aggregation_expression_multiversion_fuzzer_gen
+  - name: aggregation_expression_optimization_fuzzer_gen
+  - name: auth_gen
+  - name: .causally_consistent !.sharding
+  - name: .change_streams !.secondary_reads
+  - name: .misc_js !.non_win_dbg
+  - name: .concurrency .debug_only
+    distros:
+    - windows-vsCurrent-large
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.audit
+    distros:
+    - windows-vsCurrent-large
+  - name: .jscore .common !.auth !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: multi_shard_multi_stmt_txn_jscore_passthrough_gen
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: .read_write_concern !.large
+  - name: .read_write_concern .large
+    distros:
+    - windows-vsCurrent-large
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: .replica_sets !.large !.encrypt !.auth !.fcbis
+  - name: .replica_sets .large !.fcbis
+    distros:
+    - windows-vsCurrent-large
+  - name: .resharding_fuzzer
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+    distros:
+    - windows-vsCurrent-large
+  - name: session_jscore_passthrough
+  - name: sharding_gen
+  - name: .stitch
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+
+- &enterprise-windows-required-template
+  name: enterprise-windows-required
+  display_name: "! Enterprise Windows"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - enterprise
+  run_on:
+  - windows-vsCurrent-small
+  expansions:
+    burn_in_tests_build_variant: enterprise-windows-required
+    exe: ".exe"
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug msi archive-mh archive-mh-debug
+    content_type: application/zip
+    compile_flags: --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") --win-version-min=win10
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    multiversion_platform: windows
+    multiversion_edition: enterprise
+    jstestfuzz_num_generated_files: 35
+    target_resmoke_time: 20
+    max_sub_suites: 5
+    large_distro_name: windows-vsCurrent-large
+    push_path: windows
+    push_bucket: downloads.10gen.com
+    push_name: windows
+    push_arch: x86_64-enterprise
+    test_flags: *windows_common_test_excludes
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+      - windows-vsCurrent-xlarge
+  - name: compile_build_tools_next_TG
+    distros:
+    - windows-vsCurrent-xlarge
+  - name: build_variant_gen
+  - name: burn_in_tests_gen
+  - name: audit
+  - name: auth_audit_gen
+  - name: buildscripts_test
+  - name: causally_consistent_jscore_txns_passthrough
+    distros:
+      - windows-vsCurrent-large
+  - name: .csfle
+    distros:
+    - windows-vsCurrent-large
+  - name: .encrypt !.aggregation !.replica_sets !.sharding !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: external_auth_windows
+    distros:
+      - windows-2016-dc
+  - name: .jscore .common !.sharding
+  - name: jsCore_auth
+  - name: jsCore_ese
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .common
+  - name: mqlrun
+  - name: noPassthrough_gen
+  - name: noPassthroughWithMongod_gen
+  - name: .replica_sets .common
+  - name: .replica_sets .multi_oplog
+  - name: replica_sets_ese_gen
+  - name: sasl
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+  - name: .sharding .txns
+  - name: sharding_auth_gen
+  - name: sharding_auth_audit_gen
+  - name: sharding_ese_gen
+  - name: snmp
+  - name: unittest_shell_hang_analyzer_gen
+
+- <<: *enterprise-windows-required-template
+  name: enterprise-windows-all-feature-flags-required
+  display_name: "! Enterprise Windows (all feature flags)"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  expansions:
+    burn_in_tests_build_variant: enterprise-windows-required
+    exe: ".exe"
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug msi archive-mh archive-mh-debug
+    content_type: application/zip
+    compile_flags: --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5")  --win-version-min=win10
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    multiversion_platform: windows
+    multiversion_edition: enterprise
+    jstestfuzz_num_generated_files: 35
+    target_resmoke_time: 20
+    max_sub_suites: 5
+    large_distro_name: windows-vsCurrent-large
+    # To force disable feature flags even on the all feature flags variant, please use this file:
+    # buildscripts/resmokeconfig/fully_disabled_feature_flags.yml
+    test_flags: >-
+        --runAllFeatureFlagTests
+        --excludeWithAnyTags=incompatible_with_windows_tls
+        --excludeWithAnyTags=incompatible_with_shard_merge
+  tasks:
+    - name: change_streams_per_shard_cursor_passthrough
+    - name: cqf
+    - name: cqf_parallel
+    - name: compile_and_archive_dist_test_then_package_TG
+      distros:
+        - windows-vsCurrent-xlarge
+    - name: compile_build_tools_next_TG
+      distros:
+        - windows-vsCurrent-xlarge
+    - name: build_variant_gen
+    - name: burn_in_tests_gen
+    - name: audit
+    - name: auth_audit_gen
+    - name: causally_consistent_jscore_txns_passthrough
+      distros:
+        - windows-vsCurrent-large
+    - name: .csfle
+      distros:
+        - windows-vsCurrent-xlarge
+    - name: .encrypt !.aggregation !.replica_sets !.sharding !.jscore
+    - name: external_auth
+    - name: external_auth_aws
+    - name: external_auth_windows
+      distros:
+        - windows-2016-dc
+    - name: fle2_query_analysis
+    - name: .jscore .common !.sharding
+    - name: jsCore_auth
+    - name: jsCore_ese
+    - name: jsCore_txns_large_txns_format
+    - name: .jstestfuzz .common
+    - name: mqlrun
+    - name: noPassthrough_gen
+    - name: noPassthroughWithMongod_gen
+    - name: .replica_sets .common !.ignore_non_generated_replica_sets_jscore_passthrough
+    - name: .replica_sets .multi_oplog !.ignore_non_generated_replica_sets_jscore_passthrough
+    - name: replica_sets_jscore_passthrough_gen
+    - name: replica_sets_ese_gen
+    - name: sasl
+    - name: .sharding .txns
+    - name: sharding_auth_gen
+    - name: sharding_auth_audit_gen
+    - name: sharding_ese_gen
+    - name: snmp
+# Disabling as the following tests are not aware of feature flags.
+#    - name: buildscripts_test
+#    - name: unittest_shell_hang_analyzer_gen
+#    - name: server_selection_json_test_TG
+#    - name: server_discovery_and_monitoring_json_test_TG
+#    - name: compile_run_and_archive_dbtest_TG
+#      distros:
+#        - windows-vsCurrent-xlarge
+
+- <<: *enterprise-windows-nopush-template
+  name: enterprise-windows-benchmarks
+  display_name: "~ Enterprise Windows (Benchmarks)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  tasks:
+  - name: compile_benchmarks
+    distros:
+    - windows-vsCurrent-large
+  - name: .benchmarks !benchmarks_orphaned
+
+- <<: *enterprise-windows-nopush-template
+  name: enterprise-windows-wtdevelop
+  display_name: "~ Enterprise Windows WiredTiger develop"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - enterprise
+  - wtdevelop
+  expansions:
+    <<: *enterprise-windows-nopush-expansions-template
+    use_wt_develop: true
+
+- name: enterprise-windows-ninja
+  display_name: "Ninja Build: Enterprise Windows"
+  cron: "0 0 * * *" # Every day starting at midnight
+  modules:
+  - enterprise
+  expansions:
+    compile_flags: --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5")  --win-version-min=win10
+  tasks:
+  - name: compile_ninja_next_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: compile_ninja_TG
+    distros:
+    - windows-vsCurrent-large
+
+- name: enterprise-windows-inmem
+  display_name: Enterprise Windows (inMemory)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - windows-vsCurrent-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug msi
+    exe: ".exe"
+    content_type: application/zip
+    compile_flags: --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") --win-version-min=win10
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    test_flags: --storageEngine=inMemory --excludeWithAnyTags=requires_persistence,requires_journaling,incompatible_with_windows_tls
+    ext: zip
+    scons_cache_scope: shared
+    multiversion_platform: windows
+    multiversion_edition: enterprise
+    large_distro_name: windows-vsCurrent-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .concurrency .common
+    distros:
+    - windows-vsCurrent-large
+  - name: concurrency_replication_causal_consistency_gen
+  - name: initial_sync_fuzzer_gen
+  - name: .jscore .common !.decimal !.sharding
+  - name: .jstestfuzz .common !.flow_control  # Flow control jstestfuzz take longer.
+  - name: .read_write_concern .linearize !.durable_history
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: replica_sets_multi_stmt_txn_jscore_passthrough
+  - name: sasl
+  - name: .sharding .txns
+  - name: sharding_auth_gen
+  - name: sharding_auth_audit_gen
+  - name: snmp
+  - name: .ssl
+  - name: .resharding_fuzzer
+
+- name: windows
+  display_name: Windows
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - windows-vsCurrent-small
+  expansions:
+    additional_package_targets: msi
+    exe: ".exe"
+    push_path: windows
+    push_bucket: downloads.mongodb.org
+    push_name: windows
+    push_arch: x86_64
+    multiversion_platform: windows_x86_64-2008plus-ssl
+    multiversion_platform_42_or_later: windows_x86_64-2012plus
+    multiversion_platform_44_or_later: windows
+    multiversion_edition: base
+    content_type: application/zip
+    compile_flags: --ssl MONGO_DISTMOD=windows -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") --win-version-min=win10
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    large_distro_name: windows-vsCurrent-large
+    test_flags: *windows_common_test_excludes
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation !.auth !.encrypt !.unwind
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+    # Some concurrency workloads require a lot of memory, so we use machines
+    # with more RAM for these suites.
+  - name: .concurrency !.ubsan !.no_txns !.kill_terminate !.common !.debug_only
+    distros:
+      - windows-vsCurrent-large
+  - name: .concurrency .common
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common !.auth
+  - name: json_schema
+  - name: .jstestfuzz !.initsync !.flow_control !.stepdowns
+  - name: multiversion_gen
+  - name: multiversion_auth_gen
+  - name: .query_fuzzer
+  - name: .read_write_concern
+  - name: replica_sets_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: .updatefuzzer
+  - name: push
+    distros:
+    - rhel70-small
+
+- name: enterprise-windows
+  display_name: "Enterprise Windows"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+    - enterprise
+  run_on:
+    - windows-vsCurrent-small
+  expansions:
+    exe: ".exe"
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug msi archive-mh archive-mh-debug
+    content_type: application/zip
+    compile_flags: --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") --win-version-min=win10
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    multiversion_platform: windows
+    multiversion_edition: enterprise
+    jstestfuzz_num_generated_files: 35
+    target_resmoke_time: 20
+    max_sub_suites: 3
+    large_distro_name: windows-vsCurrent-large
+    push_path: windows
+    push_bucket: downloads.10gen.com
+    push_name: windows
+    push_arch: x86_64-enterprise
+    test_flags: *windows_common_test_excludes
+    exec_timeout_secs: 14400 # 3 hour timeout
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation !.auth !.encrypt !.unwind
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+    # Some concurrency workloads require a lot of memory, so we use machines
+    # with more RAM for these suites.
+  - name: .concurrency !.ubsan !.no_txns !.kill_terminate !.common !.debug_only
+    distros:
+      - windows-vsCurrent-large
+  - name: .concurrency .common
+  - name: .csfle
+    distros:
+    - windows-vsCurrent-large
+  - name: .publish_csfle
+    distros:
+    - rhel70-small
+  - name: disk_wiredtiger
+  - name: .jscore .common !.auth
+  - name: json_schema
+  - name: .jstestfuzz !.initsync !.flow_control !.stepdowns
+  - name: multiversion_gen
+  - name: multiversion_auth_gen
+  - name: powercycle_gen
+  - name: .query_fuzzer
+  - name: .read_write_concern
+  - name: replica_sets_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: .updatefuzzer
+  - name: push
+    distros:
+    - rhel70-small
+
+- name: enterprise-windows-cxx20-debug-experimental
+  display_name: "~ Enterprise Windows C++20 DEBUG"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+    - enterprise
+  run_on:
+    - windows-vsCurrent-small
+  expansions:
+    exe: ".exe"
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug msi archive-mh archive-mh-debug
+    content_type: application/zip
+    compile_flags: --dbg=on --opt=on --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") --win-version-min=win10 --cxx-std=20
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    scons_cache_scope: shared
+    jstestfuzz_num_generated_files: 35
+    target_resmoke_time: 20
+    max_sub_suites: 3
+    large_distro_name: windows-vsCurrent-large
+    test_flags: *windows_common_test_excludes
+    exec_timeout_secs: 14400 # 3 hour timeout
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation !.auth !.encrypt !.unwind
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+    # Some concurrency workloads require a lot of memory, so we use machines
+    # with more RAM for these suites.
+  - name: .concurrency !.ubsan !.no_txns !.kill_terminate !.common !.debug_only
+    distros:
+      - windows-vsCurrent-large
+  - name: .concurrency .common
+  - name: disk_wiredtiger
+  - name: .jscore .common !.auth
+  - name: json_schema
+  - name: .jstestfuzz !.initsync !.flow_control !.stepdowns
+  - name: powercycle_gen
+  - name: .query_fuzzer
+  - name: .read_write_concern
+  - name: replica_sets_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt !.multiversion
+  - name: .sharding .txns !.multiversion
+  - name: .sharding .common !.csrs !.multiversion
+  - name: .ssl
+  - name: .stitch
+  - name: .updatefuzzer !.multiversion
+
+- name: enterprise-windows-debug-unoptimized
+  display_name: Enterprise Windows DEBUG (Unoptimized)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - windows-vsCurrent-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    exe: ".exe"
+    content_type: application/zip
+    compile_flags: --dbg=on --opt=off --ssl MONGO_DISTMOD=windows CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(bc <<< "$(grep -c '^processor' /proc/cpuinfo) / 1.5") --win-version-min=win10
+    num_scons_link_jobs_available: 0.25
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    resmoke_jobs_max: 1
+    scons_cache_scope: shared
+    test_flags: *windows_common_test_excludes
+  tasks:
+  # This variant tests that unoptimized, DEBUG mongos and mongod binaries can run on Windows.
+  # It has a minimal amount of tasks because unoptimized builds are slow, which causes
+  # timing-sensitive tests to fail.
+  - name: compile_and_archive_dist_test_then_package_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: compile_build_tools_next_TG
+    distros:
+    - windows-vsCurrent-large
+  - name: audit
+  # Do not add more tasks to this list.
+
+###########################################
+#             OSX buildvariants           #
+###########################################
+
+- name: macos
+  display_name: macOS
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - macos-1100
+  expansions:
+    test_flags: --excludeWithAnyTags=incompatible_with_macos
+    push_path: osx
+    push_bucket: downloads.mongodb.org
+    push_name: macos
+    push_arch: x86_64
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx.vars
+    resmoke_jobs_max: 6
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_build_tools_next_TG
+  - name: build_variant_gen
+  - name: .aggregation !.auth !.encrypt !.unwind
+  - name: auth_gen
+  - name: .causally_consistent !.sharding
+  - name: .change_streams !.secondary_reads
+  - name: .misc_js
+  - name: .concurrency !.ubsan !.no_txns !.debug_only !.kill_terminate
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: initial_sync_fuzzer_gen
+  - name: .jscore .common !.auth
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .causal
+  - name: .jstestfuzz .interrupt
+  - name: .jstestfuzz .common
+  - name: .jstestfuzz .session
+  - name: .logical_session_cache .one_sec
+  - name: .query_fuzzer
+  - name: .read_write_concern !.linearize
+  - name: replica_sets_gen
+  - name: replica_sets_kill_secondaries_jscore_passthrough
+  - name: replica_sets_large_txns_format_gen
+  - name: .replica_sets .common !.auth
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: .rollbackfuzzer
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .txns
+  - name: .ssl
+  - name: .stitch
+  - name: unittest_shell_hang_analyzer_gen
+  - name: push
+    distros:
+    - rhel70-small
+
+- &macos-debug-template
+  name: macos-debug-suggested
+  display_name: "* macOS DEBUG"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  run_on:
+  - macos-1100
+  expansions: &macos-debug-expansions
+    test_flags: --excludeWithAnyTags=incompatible_with_macos
+    resmoke_jobs_max: 6
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl --dbg=on --opt=on -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx.vars
+    num_scons_link_jobs_available: 0.99
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_build_tools_next_TG
+  - name: build_variant_gen
+  - name: aggregation
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: disk_wiredtiger
+  - name: failpoints
+  - name: .jscore .common !.auth !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: mongosTest
+  - name: replica_sets_gen
+  - name: replica_sets_large_txns_format_gen
+  - name: .ssl
+  - name: .stitch
+  - name: unittest_shell_hang_analyzer_gen
+
+- name: enterprise-macos
+  display_name: Enterprise macOS
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - macos-1100
+  expansions:
+    test_flags: --excludeWithAnyTags=incompatible_with_macos,requires_gcm
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: osx
+    push_bucket: downloads.10gen.com
+    push_name: macos
+    push_arch: x86_64-enterprise
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx.vars
+    resmoke_jobs_max: 6
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_build_tools_next_TG
+  - name: build_variant_gen
+  - name: audit
+  - name: auth_audit_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.sharding !.aggregation !.jscore
+  - name: .jscore .common !.decimal !.sharding
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: mqlrun
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: push
+    distros:
+    - rhel70-small
+  - name: .csfle
+  - name: .publish_csfle
+    distros:
+    - rhel70-small
+
+- name: macos-enterprise-ninja
+  display_name: "Ninja Build: macOS Enterprise"
+  cron: "0 0 * * *" # Every day starting at midnight
+  modules:
+  - enterprise
+  run_on:
+  - macos-1100
+  expansions:
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx.vars
+  tasks:
+  - name: compile_ninja_next_TG
+  - name: compile_ninja_TG
+
+- name: enterprise-macos-rosetta-2
+  display_name: "Enterprise macOS Via Rosetta 2"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - macos-1100-arm64
+  expansions:
+    test_flags: --excludeWithAnyTags=incompatible_with_macos,requires_gcm
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx.vars
+    resmoke_jobs_max: 6
+    num_scons_link_jobs_available: 0.99
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: audit
+  - name: auth_audit_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.sharding !.aggregation !.jscore !.ssl
+  - name: .jscore .common !.decimal !.sharding
+  - name: .logical_session_cache .one_sec
+  - name: mqlrun
+  # TODO(SERVER-64009): Re-enable replica_sets_auth_gen.
+  # - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough_gen
+  - name: sasl
+  - name: .csfle
+
+- name: enterprise-macos-cxx20
+  display_name: "Enterprise macOS C++20 DEBUG"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - macos-1100
+  expansions:
+    test_flags: --excludeWithAnyTags=incompatible_with_macos,requires_gcm
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl --dbg=on --opt=on -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx.vars --cxx-std=20
+    resmoke_jobs_max: 6
+    num_scons_link_jobs_available: 0.99
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: audit
+  - name: auth_audit_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.sharding !.aggregation !.jscore !.ssl
+  - name: .jscore .common !.decimal !.sharding
+  - name: .logical_session_cache .one_sec
+  - name: mqlrun
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough_gen
+  - name: sasl
+  - name: .csfle
+
+- name: enterprise-macos-arm64
+  display_name: "~ Enterprise macOS arm64"
+  modules:
+  - enterprise
+  run_on:
+  - macos-1100-arm64
+  expansions:
+    test_flags: --excludeWithAnyTags=incompatible_with_macos
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: --ssl -j$(sysctl -n hw.logicalcpu) --libc++ --variables-files=etc/scons/xcode_macosx_arm.vars
+    resmoke_jobs_max: 6
+    num_scons_link_jobs_available: 0.99
+  tasks:
+  - name: compile_and_test_TG
+  - name: .csfle
+
+###########################################
+#          Embedded SDK buildvariants     #
+###########################################
+
+- name: embedded-sdk-macos
+  display_name: "Embedded SDK - macOS"
+  run_on:
+  - macos-1100
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  expansions:
+    test_flags: --excludeWithAnyTags=uses_transactions,incompatible_with_macos
+    cmake_path: /Applications/cmake-3.11.0-Darwin-x86_64/CMake.app/Contents/bin/cmake
+    compile_env: DEVELOPER_DIR=/Applications/Xcode13.app
+    compile_flags: >-
+      --lto
+      --variables-files=etc/scons/xcode_macosx.vars
+      -j$(sysctl -n hw.logicalcpu)
+      LIBPATH="\$BUILD_ROOT/mongo-embedded-sdk-\$MONGO_VERSION/lib"
+    cdriver_cmake_osx_deployment_target: "10.14"
+    cdriver_cmake_flags: >-
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DCMAKE_OSX_SYSROOT="$(xcrun --sdk macosx --show-sdk-path)"
+        -DCMAKE_OSX_ARCHITECTURES=x86_64
+        -DENABLE_SSL=DARWIN
+        -DENABLE_ZLIB=BUNDLED
+        -DCMAKE_C_FLAGS="-Wunguarded-availability"
+        -DCMAKE_INSTALL_RPATH=@loader_path/../lib
+    disable_unit_tests: true
+  tasks:
+  - name: embedded_sdk_build_and_test
+
+- name: embedded-sdk-ubuntu-1804-x86_64
+  display_name: "Embedded SDK - Ubuntu 18.04 x86_64"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1804-build
+  expansions:
+    test_flags: --excludeWithAnyTags=uses_transactions
+    # We need --allocator=system here to work around SERVER-27675
+    compile_flags: >-
+      --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+      -j$(grep -c ^processor /proc/cpuinfo)
+      LIBPATH="\$BUILD_ROOT/mongo-embedded-sdk-\$MONGO_VERSION/lib"
+    cdriver_cmake_flags: >-
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DCMAKE_C_COMPILER=/opt/mongodbtoolchain/v3/bin/gcc
+        -DCMAKE_CXX_COMPILER=/opt/mongodbtoolchain/v3/bin/g++
+        -DCMAKE_C_FLAGS="-flto"
+        -DCMAKE_INSTALL_RPATH=\$ORIGIN/../lib
+    disable_unit_tests: true
+  tasks:
+  - name: embedded_sdk_build_and_test
+
+###########################################
+#          Redhat buildvariants           #
+###########################################
+
+- name: enterprise-rhel-80-64-bit
+  display_name: "Enterprise RHEL 8.0"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions: &enterprise-rhel-80-64-bit-expansions
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-rhel80
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: rhel80
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    jstestfuzz_num_generated_files: 40
+    jstestfuzz_concurrent_num_files: 10
+    target_resmoke_time: 10
+    max_sub_suites: 3
+    large_distro_name: rhel80-medium
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel80-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation
+  - name: audit
+  - name: .auth
+  - name: unittest_shell_hang_analyzer_gen
+  - name: .causally_consistent !.sharding
+  - name: .change_streams
+  - name: .change_stream_fuzzer
+  - name: .misc_js
+  - name: .concurrency !.large !.ubsan !.no_txns !.debug_only
+  - name: .concurrency .large !.ubsan !.no_txns !.debug_only
+    distros:
+    - rhel80-medium
+  - name: disk_wiredtiger
+  - name: .encrypt
+  - name: idl_tests
+  - name: initial_sync_fuzzer_gen
+  - name: .integration
+    distros:
+    - rhel80-medium
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .jstestfuzz !.flow_control  # Flow control jstestfuzz take longer.
+  - name: libunwind_tests
+  - name: mqlrun
+  - name: .multi_shard
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: multiversion_gen
+  - name: .query_fuzzer
+  - name: .random_multiversion_ds
+  - name: .read_write_concern .large
+    distros:
+    - rhel80-medium
+  - name: .read_write_concern !.large
+  - name: .replica_sets !.encrypt !.auth
+    distros:
+    - rhel80-medium
+  - name: replica_sets_api_version_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: .resharding_fuzzer
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: sharding_api_version_jscore_passthrough_gen
+  - name: .sharding .txns
+  - name: .sharding .common
+  - name: snmp
+  - name: .stitch
+  - name: .updatefuzzer
+  - name: secondary_reads_passthrough_gen
+  - name: server_discovery_and_monitoring_json_test_TG
+    distros:
+      - rhel80-large
+  - name: server_selection_json_test_TG
+    distros:
+      - rhel80-large
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: selinux_rhel8_enterprise
+  - name: .publish
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- &enterprise-rhel-80-64-bit-dynamic-required-template
+  name: enterprise-rhel-80-64-bit-dynamic-required
+  display_name: "! Shared Library Enterprise RHEL 8.0"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions: &enterprise-rhel-80-64-bit-dynamic-required-expansions
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    has_packages: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    jstestfuzz_num_generated_files: 40
+    jstestfuzz_concurrent_num_files: 10
+    target_resmoke_time: 10
+    max_sub_suites: 5
+    idle_timeout_factor: 1.5
+    exec_timeout_factor: 1.5
+    large_distro_name: rhel80-medium
+    burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem linux-64-duroff enterprise-rhel-80-64-bit-multiversion
+    num_scons_link_jobs_available: 0.99
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-xlarge
+#  - name: compile_test_and_package_parallel_unittest_stream_with_recording_TG
+#    distros:
+#      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+  - name: .lint
+  - name: lint_fuzzer_sanity_patch
+  - name: test_api_version_compatibility
+  - name: burn_in_tests_gen
+  - name: check_feature_flag_tags
+  - name: check_for_todos
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation
+  - name: audit
+  - name: .auth
+  - name: burn_in_tags_gen
+  - name: buildscripts_test
+  - name: resmoke_end2end_tests
+  - name: unittest_shell_hang_analyzer_gen
+  - name: .causally_consistent !.sharding
+  - name: .change_streams
+  - name: .change_stream_fuzzer
+  - name: .misc_js
+  - name: .concurrency !.large !.ubsan !.no_txns !.debug_only
+  - name: .concurrency .large !.ubsan !.no_txns !.debug_only
+    distros:
+    - rhel80-medium
+  - name: config_fuzzer_concurrency
+  - name: config_fuzzer_simulate_crash_concurrency_replication
+    distros:
+    - rhel80-large
+  - name: config_fuzzer_concurrency_replication
+    distros:
+    - rhel80-large
+  - name: config_fuzzer_jsCore
+  - name: config_fuzzer_replica_sets_jscore_passthrough
+    distros:
+    - rhel80-large
+  - name: disk_wiredtiger
+  - name: .encrypt
+  - name: idl_tests
+  - name: initial_sync_fuzzer_gen
+  - name: .integration
+    distros:
+    - rhel80-medium
+  - name: jsCore
+    distros:
+    - rhel80-xlarge
+  - name: .jscore .common !jsCore
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .jstestfuzz !.flow_control  # Flow control jstestfuzz take longer.
+  - name: libunwind_tests
+  - name: .multiversion_sanity_check
+  - name: mqlrun
+  - name: .multi_shard
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: multiversion_gen
+  - name: .query_fuzzer
+  - name: .random_multiversion_ds
+  - name: .read_write_concern .large
+    distros:
+    - rhel80-medium
+  - name: .read_write_concern !.large
+  - name: .replica_sets !.encrypt !.auth
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_api_version_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: sharding_api_version_jscore_passthrough_gen
+  - name: .sharding .txns
+  - name: .sharding .common
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+    distros:
+      - rhel80-xlarge
+  - name: csfle_build_debug_and_test
+    distros:
+      - rhel80-xlarge
+  - name: .updatefuzzer
+  - name: secondary_reads_passthrough_gen
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: .serverless
+    distros:
+      - rhel80-xlarge
+  - name: server_selection_json_test_TG
+    distros:
+      - rhel80-xlarge
+
+- name: enterprise-rhel-80-64-bit-dynamic-required-ninja
+  display_name: "Ninja Build: Enterprise RHEL 8.0"
+  cron: "0 0 * * *" # Every day at midnight
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions:
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    has_packages: false
+  tasks:
+  - name: compile_ninja_next_TG
+    distros:
+    - rhel80-xlarge
+  - name: compile_ninja_TG
+    distros:
+    - rhel80-xlarge
+
+- &enterprise-rhel-80-64-bit-dynamic-all-feature-flags-required-template
+  name: enterprise-rhel-80-64-bit-dynamic-all-feature-flags-required
+  display_name: "! Shared Library Enterprise RHEL 8.0 (all feature flags)"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  stepback: false
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions: &enterprise-rhel-80-64-bit-dynamic-all-feature-flags-expansions
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    has_packages: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    jstestfuzz_num_generated_files: 40
+    jstestfuzz_concurrent_num_files: 10
+    target_resmoke_time: 10
+    max_sub_suites: 5
+    large_distro_name: rhel80-medium
+    num_scons_link_jobs_available: 0.99
+    # To force disable feature flags even on the all feature flags variant, please use this file:
+    # buildscripts/resmokeconfig/fully_disabled_feature_flags.yml
+    test_flags: >-
+      --runAllFeatureFlagTests
+      --excludeWithAnyTags=incompatible_with_shard_merge
+  tasks: &enterprise-rhel-80-64-bit-dynamic-all-feature-flags-tasks
+  - name: change_streams_per_shard_cursor_passthrough
+  - name: cqf
+  - name: cqf_parallel
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-large
+# Disabling as the following tests are not aware of feature flags.
+#  - name: compile_test_and_package_parallel_unittest_stream_TG
+#    distros:
+#      - rhel80-large
+#  - name: compile_test_and_package_parallel_dbtest_stream_TG
+#    distros:
+#    - rhel80-medium
+  - name: libdeps_graph_linting_TG
+    distros:
+      - rhel80-large
+  - name: build_variant_gen
+  - name: burn_in_tests_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation
+  - name: audit
+  - name: .auth
+  - name: unittest_shell_hang_analyzer_gen
+  - name: .causally_consistent !.sharding
+  - name: .change_streams
+  - name: .change_stream_fuzzer
+  - name: .misc_js
+  - name: .clustered_collections
+  - name: .concurrency !.large !.ubsan !.no_txns !.debug_only
+  - name: .concurrency .large !.ubsan !.no_txns !.debug_only
+    distros:
+    - rhel80-medium
+  - name: disk_wiredtiger
+  - name: .encrypt
+  - name: feature_flag_multiversion_gen
+  - name: fle2_query_analysis
+  - name: idl_tests
+  - name: initial_sync_fuzzer_gen
+  - name: .integration
+    distros:
+    - rhel80-medium
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .jstestfuzz !.flow_control  # Flow control jstestfuzz take longer.
+  - name: libunwind_tests
+  - name: mqlrun
+  - name: .multi_shard
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: multiversion_gen
+  - name: powercycle_smoke
+  - name: .query_fuzzer
+  - name: .random_multiversion_ds
+  - name: .read_write_concern .large
+    distros:
+    - rhel80-medium
+  - name: .read_write_concern !.large
+  - name: .replica_sets !.encrypt !.auth
+    distros:
+    - rhel80-medium
+  - name: replica_sets_api_version_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: sharding_api_version_jscore_passthrough_gen
+  - name: .sharding .txns
+  - name: .sharding .common
+  - name: sharded_multi_stmt_txn_jscore_passthrough
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+    distros:
+      - rhel80-xlarge
+  - name: .serverless
+  - name: .updatefuzzer
+  - name: secondary_reads_passthrough_gen
+# Disabling as the following tests are not aware of feature flags.
+#  - name: server_discovery_and_monitoring_json_test_TG
+#    distros:
+#      - rhel80-large
+#  - name: server_selection_json_test_TG
+#    distros:
+#      - rhel80-large
+
+- &enterprise-rhel-80-64-bit-dynamic-classic-engine
+  name: enterprise-rhel-80-64-bit-dynamic-classic-engine
+  display_name: "Shared Library Enterprise RHEL 8.0 (Classic Engine)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  stepback: false
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions: &enterprise-rhel-80-64-bit-dynamic-classic-engine-expansions
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    has_packages: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    jstestfuzz_num_generated_files: 40
+    jstestfuzz_concurrent_num_files: 10
+    target_resmoke_time: 10
+    max_sub_suites: 5
+    large_distro_name: rhel80-medium
+    burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem linux-64-duroff enterprise-rhel-80-64-bit-multiversion
+    num_scons_link_jobs_available: 0.99
+    test_flags: >-
+      --mongodSetParameters="{internalQueryForceClassicEngine: true}"
+  tasks:
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: .aggregation
+  - name: .auth
+  - name: .causally_consistent !.sharding
+  - name: .change_stream_fuzzer
+  - name: .change_streams
+  - name: .concurrency !.large !.ubsan !.no_txns !.debug_only
+  - name: .concurrency .large !.ubsan !.no_txns !.debug_only
+    distros:
+    - rhel80-medium
+  - name: .encrypt
+  - name: .integration
+    distros:
+    - rhel80-medium
+  - name: .jscore .common !jsCore
+  - name: .jstestfuzz !.flow_control
+  - name: .lint
+  - name: .misc_js
+  - name: .multi_shard
+  - name: .query_fuzzer
+  - name: .random_multiversion_ds
+  - name: .read_only
+  - name: .read_write_concern !.large
+  - name: .read_write_concern .large
+    distros:
+    - rhel80-medium
+  - name: .replica_sets !.encrypt !.auth
+    distros:
+    - rhel80-xlarge
+  - name: .rollbackfuzzer
+  - name: .sharding .common
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .txns
+  - name: .stitch
+  - name: .serverless
+    distros:
+      - rhel80-xlarge
+  - name: .updatefuzzer
+  - name: audit
+  - name: build_variant_gen
+  - name: burn_in_tags_gen
+  - name: burn_in_tests_gen
+  - name: check_feature_flag_tags
+  - name: check_for_todos
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+    - rhel80-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - rhel80-xlarge
+#  - name: compile_test_and_package_parallel_unittest_stream_with_recording_TG
+#    distros:
+#      - rhel80-xlarge
+  - name: disk_wiredtiger
+  - name: initial_sync_fuzzer_gen
+  - name: jsCore
+    distros:
+    - rhel80-xlarge
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: lint_fuzzer_sanity_patch
+  - name: mqlrun
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: multiversion_gen
+  - name: .multiversion_sanity_check
+  - name: replica_sets_api_version_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_passthrough_gen
+  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: replica_sets_reconfig_kill_primary_jscore_passthrough_gen
+    distros:
+    - rhel80-xlarge
+  - name: retryable_writes_jscore_passthrough_gen
+  - name: retryable_writes_jscore_stepdown_passthrough_gen
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: secondary_reads_passthrough_gen
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+    distros:
+      - rhel80-xlarge
+  - name: session_jscore_passthrough
+  - name: sharding_api_version_jscore_passthrough_gen
+  - name: snmp
+  - name: test_api_version_compatibility
+  - name: unittest_shell_hang_analyzer_gen
+
+- name: enterprise-rhel-80-64-bit-large-txns-format
+  display_name: "Enterprise RHEL 8.0 (large transactions format)"
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    compile_flags: >-
+      --ssl
+      MONGO_DISTMOD=rhel80
+      -j$(grep -c ^processor /proc/cpuinfo)
+      --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: rhel80-medium
+    test_flags: >-
+        --mongodSetParameters="{maxNumberOfTransactionOperationsInSingleOplogEntry: 2}"
+        --excludeWithAnyTags=exclude_from_large_txns
+  tasks:
+  - name: compile_and_archive_dist_test_then_package_TG
+    distros:
+    - rhel80-large
+  - name: build_variant_gen
+  - name: auth_gen
+  - name: auth_audit_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: change_streams
+  - name: change_streams_whole_db_passthrough
+  - name: change_streams_whole_cluster_passthrough
+  - name: concurrency_replication_gen
+  - name: concurrency_replication_multi_stmt_txn_gen
+  - name: concurrency_sharded_replication_gen
+  - name: concurrency_sharded_replication_with_balancer_gen
+  - name: concurrency_sharded_clusterwide_ops_add_remove_shards_gen
+  - name: concurrency_sharded_local_read_write_multi_stmt_txn_gen
+  - name: concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer_gen
+  - name: concurrency_sharded_multi_stmt_txn_gen
+  - name: concurrency_sharded_multi_stmt_txn_with_balancer_gen
+  - name: concurrency_sharded_multi_stmt_txn_with_stepdowns_gen
+  - name: concurrency_sharded_with_stepdowns_gen
+  - name: concurrency_sharded_with_stepdowns_and_balancer_gen
+  - name: initial_sync_fuzzer_gen
+  - name: jsCore
+  - name: jsCore_txns
+  - name: .logical_session_cache .repl
+  - name: .multi_shard
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: multiversion_auth_gen
+  - name: multiversion_gen
+  - name: noPassthrough_gen
+  - name: .replica_sets !.multi_oplog !.large
+  - name: .replica_sets !.multi_oplog .large
+    distros:
+    - rhel80-medium
+  - name: .resharding_fuzzer
+  - name: .rollbackfuzzer
+  - name: .sharding .txns
+  - name: sharding_gen
+  - name: sharding_auth_gen
+  - name: sharding_auth_audit_gen
+  - name: sharding_ese_gen
+  - name: sharding_ese_gcm_gen
+  - name: sharding_csrs_continuous_config_stepdown_gen
+  - name: sharded_multi_stmt_txn_jscore_passthrough
+    distros:
+    - rhel80-medium
+  - name: generate_buildid_to_debug_symbols_mapping
+
+# This build variant is used to run multiversion tests as part of burn_in_tags as these tests are
+# currently only run on our daily builders.
+- &enterprise-rhel-80-64-bit-multiversion-template
+  name: enterprise-rhel-80-64-bit-multiversion
+  display_name: "Enterprise RHEL 8.0 (implicit multiversion)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions: &enterprise-rhel-80-64-bit-multiversion-expansions-template
+    compile_flags: >-
+      -j$(grep -c ^processor /proc/cpuinfo)
+      --ssl
+      --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+      MONGO_DISTMOD=rhel80
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    tooltags: "ssl sasl gssapi"
+    build_mongoreplay: true
+    large_distro_name: rhel80-medium
+    resmoke_jobs_factor: 0.25
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+  - name: .multiversion_fuzzer
+  - name: .multiversion_passthrough
+  - name: .random_multiversion_ds
+
+- <<: *enterprise-rhel-80-64-bit-multiversion-template
+  name: enterprise-rhel-80-64-bit-multiversion-all-feature-flags
+  display_name: "Enterprise RHEL 8.0 (implicit multiversion & all feature flags)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  expansions:
+    <<: *enterprise-rhel-80-64-bit-multiversion-expansions-template
+    # No feature flag tests since they aren't compatible with the older binaries.
+    test_flags: >-
+      --runAllFeatureFlagsNoTests
+      --excludeWithAnyTags=incompatible_with_shard_merge
+
+- name: enterprise-rhel-80-64-bit-future-git-tag-multiversion
+  display_name: "Enterprise RHEL 8.0 (future git tag multiversion)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions:
+    compile_flags: >-
+      -j$(grep -c ^processor /proc/cpuinfo)
+      --ssl
+      --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+      MONGO_DISTMOD=rhel80
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    tooltags: "ssl sasl gssapi"
+    build_mongoreplay: true
+    large_distro_name: rhel80-medium
+    resmoke_jobs_factor: 0.25
+    bv_future_git_tag: r100.0.0-9999
+    test_flags: >-
+      --excludeWithAnyTags=future_git_tag_incompatible
+  tasks:
+    - name: compile_test_and_package_serial_TG
+      distros:
+      - rhel80-xlarge
+    - name: build_variant_gen
+    - name: .multiversion !.future_git_tag_incompatible
+    - name: .multiversion_future_git_tag
+
+#- name: rhel-80-64-bit-nossl
+#  display_name: "RHEL 8.0 Shared Library (No SSL)"
+#  run_on:
+#  - rhel80-small
+#  cron: "0 12 * * *" # Every day starting at 12:00
+#  expansions:
+#    compile_flags: >-
+#      -j$(grep -c ^processor /proc/cpuinfo)
+#      --ssl=off
+#      --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+#      MONGO_DISTMOD=rhel80
+#      --link-model=dynamic
+#    multiversion_platform: rhel80
+#    multiversion_edition: enterprise
+#    scons_cache_scope: shared
+#    build_mongoreplay: false
+#    large_distro_name: rhel80-medium
+#  tasks:
+#  - name: compile_test_and_package_serial_TG
+#    distros:
+#    - rhel80-large
+#  - name: jsCore
+
+
+- &enterprise-rhel-70-64-bit-template
+  name: enterprise-rhel-70-64-bit
+  display_name: "Enterprise RHEL 7.0"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel70-small
+  expansions: &enterprise-rhel-70-64-bit-expansions-template
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-rhel70
+    compile_flags: --ssl MONGO_DISTMOD=rhel70 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: rhel70
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: rhel70
+    repo_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel70
+  - name: compile_build_tools_next_TG
+    distros:
+    - rhel70
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: config_fuzzer_concurrency
+  - name: config_fuzzer_simulate_crash_concurrency_replication
+    distros:
+    - rhel70-large
+  - name: config_fuzzer_concurrency_replication
+    distros:
+    - rhel70-large
+  - name: config_fuzzer_jsCore
+  - name: config_fuzzer_replica_sets_jscore_passthrough
+    distros:
+    - rhel70-large
+  - name: .encrypt !.sharding !.replica_sets !.aggregation !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .common
+  - name: libunwind_tests
+  - name: .logical_session_cache .one_sec
+  - name: .ocsp
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .replica_sets .multi_oplog
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: sharding_auth_audit_gen
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: unittest_shell_hang_analyzer_gen
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: selinux_rhel7_enterprise
+  - name: .publish
+    distros:
+    - rhel70-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: ubi8
+  display_name: "UBI 8"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubi8
+  expansions:
+    resmoke_jobs_factor: 1
+    disable_shared_scons_cache: true
+    compile_flags: MONGO_DISTMOD=rhel80 --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    tooltags: ""
+    build_mongoreplay: true
+    test_flags: >-
+      --excludeWithAnyTags=requires_os_access
+  tasks:
+  - name: compile_and_archive_dist_test_then_package_TG
+    distros:
+    - rhel80-large
+  - name: build_variant_gen
+  - name: jsCore
+  - name: sharding_gen
+  - name: replica_sets_gen
+
+- &enterprise-rhel-80-64-bit-suggested-template
+  name: enterprise-rhel-80-64-bit-suggested
+  display_name: "* Enterprise RHEL 8.0"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-build
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-rhel80
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: rhel80
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: rhel80-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.sharding !.replica_sets !.aggregation !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: libunwind_tests
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .replica_sets .multi_oplog
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: sharding_auth_audit_gen
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: selinux_rhel8_enterprise
+  - name: .publish
+    distros:
+    - rhel80-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-rhel-82-arm64
+  display_name: "Enterprise RHEL 8.2 arm64"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel82-arm64-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: aarch64-enterprise-rhel82
+    compile_flags: --ssl MONGO_DISTMOD=rhel82 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: aarch64
+    packager_distro: rhel82
+    repo_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel82-arm64-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer !.multiversion # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.sharding !.replica_sets !.aggregation !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .replica_sets .multi_oplog
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: sharding_auth_audit_gen
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - rhel80-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+# This variant is to intentionally test uncommon features nightly
+#- <<: *enterprise-rhel-70-64-bit-template
+#  name: enterprise-rhel-70-64-bit-kitchen-sink
+#  display_name: "~ Enterprise RHEL 7.0"
+#  cron: "0 12 * * *" # Every day starting at 12:00
+#  expansions:
+#    <<: *enterprise-rhel-70-64-bit-expansions-template
+#    compile_flags: --ssl MONGO_DISTMOD=rhel70 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+#  tasks:
+#  - name: compile_test_and_package_serial_TG
+#    distros:
+#    - rhel70
+#  - name: jsCore
+
+- <<: *enterprise-rhel-70-64-bit-template
+  name: hot_backups-rhel-70-64-bit
+  display_name: "hot_backups RHEL 7.0"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel70
+  expansions:
+    <<: *enterprise-rhel-70-64-bit-expansions-template
+    additional_package_targets: ""
+    compile_flags: --ssl MONGO_DISTMOD=rhel70 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --enterprise-features=hot_backups
+    has_packages: false
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+  - name: jsCore
+  - name: noPassthroughHotBackups_gen
+
+- <<: *enterprise-rhel-70-64-bit-template
+  name: enterprise-rhel-70-64-bit-no-libunwind
+  display_name: "~ Enterprise RHEL 7.0 (no-libunwind)"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  run_on:
+  - rhel70
+  expansions:
+    <<: *enterprise-rhel-70-64-bit-expansions-template
+    compile_flags: --ssl MONGO_DISTMOD=rhel70 --use-libunwind=off --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    has_packages: false
+    additional_package_targets: ""
+  # Override list of tasks to exclude package testing and publishing
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel70
+  - name: build_variant_gen
+#  - name: .aggfuzzer # Disabled for FCV 5.3
+  - name: audit
+  - name: auth_audit_gen
+  - name: auth_gen
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.sharding !.replica_sets !.aggregation !.jscore
+  - name: external_auth
+  - name: external_auth_aws
+  - name: .jscore .common !.decimal !.sharding
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: .replica_sets .multi_oplog
+  - name: sasl
+  - name: search
+  - name: search_auth
+  - name: search_ssl
+  - name: sharding_auth_audit_gen
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+
+- name: ubuntu1804-debug-suggested
+  display_name: "* Shared Library Ubuntu 18.04 DEBUG"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  run_on:
+  - ubuntu1804-test
+  expansions:
+    resmoke_jobs_factor: 0.5  # Avoid starting too many mongod's
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    num_scons_link_jobs_available: 0.99
+    large_distro_name: ubuntu1804-large
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_build_tools_next_TG
+    distros:
+    - ubuntu1804-xlarge
+  - name: build_variant_gen
+  - name: jsCore
+  - name: .read_write_concern !.write !.aggregation
+  - name: replica_sets_jscore_passthrough
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: sharded_collections_jscore_passthrough
+  - name: sharding_gen
+  - name: sharding_auth_gen
+  - name: .stitch
+  - name: unittest_shell_hang_analyzer_gen
+
+
+- name: ubuntu1804-sbe-yielding-debug
+  display_name: "Shared Library Ubuntu 18.04 DEBUG Yielding Support for SBE"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1804-test
+  expansions:
+    resmoke_jobs_factor: 0.5  # Avoid starting too many mongod's
+    compile_flags: --dbg=on --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    num_scons_link_jobs_available: 0.99
+    large_distro_name: ubuntu1804-large
+    test_flags: >-
+      --mongodSetParameters="{maintainValidCursorsAcrossSBEYieldandReadCommands: true}"
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: build_variant_gen
+  - name: jsCore
+  - name: .aggregation !.encrypt
+  - name: replica_sets_jscore_passthrough
+  - name: sharded_collections_jscore_passthrough
+  - name: sharding_gen
+  - name: noPassthrough_gen
+  - name: noPassthroughWithMongod_gen
+  # Exclude concurrency tasks which are ubsan-specific, test interaction between causal consistency
+  # and transactions, or involve stepdowns/termination. These should not have any particularly
+  # interesting interaction with the new yielding behavior and may exceed the standard testing time
+  # limits.
+  - name: .concurrency !.ubsan !.no_txns !.stepdowns !.kill_terminate
+
+- name: ubuntu1804-container
+  display_name: "Ubuntu 18.04 Container"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1804-container-server
+  expansions:
+    resmoke_jobs_factor: 1
+    disable_shared_scons_cache: true
+    compile_flags: MONGO_DISTMOD=ubuntu1804 --opt=on -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    tooltags: ""
+    build_mongoreplay: true
+    test_flags: >-
+      --excludeWithAnyTags=requires_os_access
+  tasks:
+  - name: compile_and_archive_dist_test_then_package_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: jsCore
+  - name: sharding_gen
+  - name: replica_sets_gen
+
+- name: rhel70
+  display_name: RHEL 7.0
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel70-small
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-rhel70
+    compile_flags: --ssl MONGO_DISTMOD=rhel70 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: rhel70
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: rhel70
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: rhel70
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel70
+  - name: build_variant_gen
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+    distros:
+      - rhel70
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: selinux_rhel7_org
+  - name: .publish
+    distros:
+    - rhel70-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: rhel80
+  display_name: RHEL 8.0
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel80-build
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-rhel80
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: rhel80
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: rhel80
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: rhel80-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel80-build
+  - name: build_variant_gen
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+    distros:
+      - rhel80-build
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - rhel80-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: rhel-82-arm64
+  display_name: RHEL 8.2 arm64
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel82-arm64-small
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: aarch64-rhel82
+    compile_flags: --ssl MONGO_DISTMOD=rhel82 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: aarch64
+    packager_distro: rhel82
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: rhel82-arm64-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel82-arm64-large
+  - name: build_variant_gen
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+    distros:
+      - rhel82-arm64-large
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs !.multiversion
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - rhel80-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+# This variant compiles on RHEL 7.0 and runs tests on RHEL 7.6
+- name: rhel76_compile_rhel70
+  display_name: RHEL 7.0/7.6 Cross-ABI
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel76-test
+  expansions:
+    compile_flags: --ssl MONGO_DISTMOD=rhel70 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+  tasks:
+  - name: compile_and_archive_dist_test_then_package_TG
+    distros:
+    - rhel70
+  - name: build_variant_gen
+  - name: .ssl
+  - name: jsCore
+  - name: external_auth
+
+- name: enterprise-rhel-81-ppc64le
+  display_name: Enterprise RHEL 8.1 PPC64LE
+  modules:
+  - enterprise
+  run_on:
+  - rhel81-power8-small
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    # We need to compensate for SMT8 setting the cpu count very high and lower the amount of parallelism down
+    compile_flags: --ssl MONGO_DISTMOD=rhel81 -j$(echo "$(grep -c processor /proc/cpuinfo)/2" | bc) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    resmoke_jobs_factor: 0.25
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: ppc64le
+    packager_distro: rhel81
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: ppc64le-enterprise-rhel81
+    repo_edition: enterprise
+    multiversion_platform: rhel81
+    multiversion_architecture: ppc64le
+    multiversion_edition: enterprise
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel81-power8-large
+  - name: build_variant_gen
+  - name: .aggregation .common
+  - name: audit
+  - name: .auth !.multiversion !.jscore
+  - name: .misc_js
+  - name: .encrypt
+  - name: .integration !.audit
+    distros:
+    - rhel81-power8-large
+  - name: .jscore .common !.auth
+  - name: .read_write_concern
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: sasl
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.multiversion
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+    distros:
+    - rhel70-small
+  - name: .publish
+    distros:
+    - rhel70-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-rhel-72-s390x-compile
+  display_name: Enterprise RHEL 7.2 s390x Compile
+  modules:
+  - enterprise
+  run_on:
+  - rhel72-zseries-test
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    release_buid: true
+    compile_flags: --ssl MONGO_DISTMOD=rhel72 -j3 --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    resmoke_jobs_max: 2
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: s390x
+    packager_distro: rhel72
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: s390x-enterprise-rhel72
+    repo_edition: enterprise
+    multiversion_platform: rhel72
+    multiversion_architecture: s390x
+    multiversion_edition: enterprise
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel72-zseries-build
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-rhel-72-s390x
+  display_name: Enterprise RHEL 7.2 s390x
+  modules:
+  - enterprise
+  run_on:
+  - rhel72-zseries-test
+  cron: "0 0 1 1 *" # Every year starting 1/1 at 00:00
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    release_buid: true
+    compile_flags: --ssl MONGO_DISTMOD=rhel72 -j3 --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    resmoke_jobs_max: 2
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: s390x
+    packager_distro: rhel72
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: s390x-enterprise-rhel72
+    repo_edition: enterprise
+    multiversion_platform: rhel72
+    multiversion_architecture: s390x
+    multiversion_edition: enterprise
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel72-zseries-build
+  - name: build_variant_gen
+  - name: .aggregation .common
+  - name: audit
+  - name: .auth !.multiversion !.jscore
+  - name: .misc_js
+  - name: .encrypt
+  - name: .integration !.audit
+    distros:
+    - rhel72-zseries-build
+  - name: .jscore .common !.auth
+  - name: .read_write_concern
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: sasl
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.multiversion
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+    distros:
+    - rhel70-small
+  - name: .publish
+    distros:
+    - rhel70-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+###########################################
+#          Ubuntu buildvariants           #
+###########################################
+
+- name: enterprise-ubuntu-dynamic-1804-clang-tidy-required
+  display_name: "! Enterprise Clang Tidy"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - enterprise
+  run_on:
+   - ubuntu1804-xlarge
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    compile_flags: --link-model=dynamic -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars
+    # Unlike static builds, dynamic builds have no need to
+    # constrain the number of link jobs. Unfortunately, --jlink=1
+    # means one link job, not 100%. So this is a bit gross but set
+    # it to .99.
+    num_scons_link_jobs_available: 0.99
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    show_scons_timings: false
+  tasks:
+  - name: clang_tidy_TG
+
+###########################################
+#          SUSE buildvariants             #
+###########################################
+
+- name: enterprise-suse12-64
+  display_name: Enterprise SLES 12
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - suse12-sp5-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-suse12
+    compile_flags: --ssl MONGO_DISTMOD=suse12 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: suse12
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: suse12
+    repo_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - suse12-sp5-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.aggregation !.sharding !.jscore
+  - name: .jscore .common !.decimal !.sharding
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - suse12-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: suse12
+  display_name: SUSE 12
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - suse12-sp5-small
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-suse12
+    compile_flags: --ssl MONGO_DISTMOD=suse12 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: suse12
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: suse12
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: suse12-sp5-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - suse12-sp5-large
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common !.large
+  - name: .concurrency .common .large
+    distros:
+      - suse12-sp5-large
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common !.decimal
+  - name: .jstestfuzz .common
+  - name: multiversion_gen
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: .publish
+    distros:
+    - suse12-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-suse15-64
+  display_name: Enterprise SLES 15
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - suse15-test
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-suse15
+    compile_flags: --ssl MONGO_DISTMOD=suse15 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: suse15
+    repo_edition: enterprise
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - suse15-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common !.multiversion # Disabled for FCV 5.3
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.aggregation !.sharding !.jscore
+  - name: .jscore .common !.decimal !.sharding
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: .publish
+    distros:
+    - suse15-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: suse15
+  display_name: SUSE 15
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - suse15-test
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-suse15
+    compile_flags: --ssl MONGO_DISTMOD=suse15 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: linux_x86_64
+    multiversion_edition: base
+    multiversion_platform_42_or_later: suse15
+    multiversion_edition_42_or_later: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: suse15
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: suse15-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - suse15-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common !.multiversion # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common !.decimal
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .txns
+  - name: .sharding .common !.csrs !.multiversion
+  - name: .ssl
+  - name: .stitch
+  - name: .publish
+    distros:
+    - suse15-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+###########################################
+#          Debian buildvariants           #
+###########################################
+
+- name: enterprise-debian92-64
+  display_name: Enterprise Debian 9.2
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - debian92-test
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-debian92
+    compile_flags: --ssl MONGO_DISTMOD=debian92 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    num_scons_link_jobs_available: 0.0625
+    multiversion_platform: debian92
+    multiversion_edition: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: debian92
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: debian92-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - debian92-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.aggregation !.sharding !.jscore
+  - name: .jscore .common !.decimal !.sharding
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - debian92-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: debian92
+  display_name: Debian 9.2
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - debian92-test
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-debian92
+    compile_flags: --ssl MONGO_DISTMOD=debian92 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    num_scons_link_jobs_available: 0.0625
+    multiversion_platform: debian92
+    multiversion_edition: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: debian92
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: debian92-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - debian92-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: aggregation_auth
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common !.decimal
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - debian92-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: enterprise-debian10-64
+  display_name: Enterprise Debian 10
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - debian10-test
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+    push_path: linux
+    push_bucket: downloads.10gen.com
+    push_name: linux
+    push_arch: x86_64-enterprise-debian10
+    compile_flags: --ssl MONGO_DISTMOD=debian10 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+    multiversion_platform: linux_x86_64
+    multiversion_edition: base
+    multiversion_platform_42_or_later: debian10
+    multiversion_edition_42_or_later: enterprise
+    has_packages: true
+    packager_script: packager_enterprise.py
+    packager_arch: x86_64
+    packager_distro: debian10
+    repo_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: debian10-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - debian10-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: audit
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .encrypt !.replica_sets !.aggregation !.sharding !.jscore
+  - name: .jepsen_docker
+    distros:
+    - debian10-large
+  - name: .jscore .common !.decimal !.sharding
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: replica_sets_auth_gen
+  - name: replica_sets_jscore_passthrough
+  - name: sasl
+  - name: sharding_auth_gen
+  - name: snmp
+  - name: .stitch
+  - name: .csfle
+  - name: .publish_csfle
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - debian10-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+- name: debian10
+  display_name: Debian 10
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - debian10-test
+  expansions:
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux
+    push_arch: x86_64-debian10
+    compile_flags: --ssl MONGO_DISTMOD=debian10 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: linux_x86_64
+    multiversion_edition: base
+    multiversion_platform_42_or_later: debian10
+    multiversion_edition_42_or_later: targeted
+    has_packages: true
+    packager_script: packager.py
+    packager_arch: x86_64
+    packager_distro: debian10
+    repo_edition: org
+    scons_cache_scope: shared
+    large_distro_name: debian10-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - debian10-build
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: aggregation
+  - name: aggregation_auth
+  - name: .auth !.audit !.multiversion
+  - name: causally_consistent_jscore_txns_passthrough
+  - name: .misc_js
+  - name: .concurrency .common
+  - name: concurrency_replication_causal_consistency_gen
+  - name: disk_wiredtiger
+  - name: free_monitoring
+  - name: .jscore .common !.decimal
+  - name: .jstestfuzz .common
+  - name: .logical_session_cache .one_sec
+  - name: multiversion_gen
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+  - name: .ssl
+  - name: .stitch
+  - name: test_packages
+    distros:
+    - ubuntu2004-package
+  - name: .publish
+    distros:
+    - debian10-small
+  - name: generate_buildid_to_debug_symbols_mapping
+
+################################
+# storage engine buildvariants #
+################################
+
+- name: enterprise-rhel-80-benchmarks
+  display_name: Enterprise RHEL 8.0 (Benchmarks)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-medium
+  expansions:
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+  tasks:
+  - name: compile_benchmarks
+  - name: .benchmarks
+
+- name: enterprise-rhel-80-64-bit-inmem
+  display_name: Enterprise RHEL 8.0 (inMemory)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - rhel80-small
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    test_flags: --storageEngine=inMemory --excludeWithAnyTags=requires_persistence,requires_journaling
+    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: rhel80
+    multiversion_edition: enterprise
+    scons_cache_scope: shared
+    large_distro_name: rhel80-large
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - rhel80-xlarge
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: .aggregation !.unwind !.encrypt
+  - name: audit
+  - name: .auth !.multiversion
+  - name: .causally_consistent !.wo_snapshot !.durable_history
+  - name: .change_streams !.secondary_reads
+  - name: .change_stream_fuzzer
+  - name: .misc_js
+  - name: .concurrency !.ubsan !.no_txns !.debug_only !.kill_terminate
+    distros:
+    - rhel80-medium  # Some workloads require a lot of memory, use a bigger machine for this suite.
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.audit
+    distros:
+    - rhel80-medium
+  - name: .jscore .common !.decimal
+  - name: jsCore_txns_large_txns_format
+  - name: .jstestfuzz !.initsync
+  - name: .logical_session_cache
+  - name: .multi_shard .common
+  - name: multi_stmt_txn_jscore_passthrough_with_migration_gen
+  - name: .read_write_concern !.durable_history
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  - name: .replica_sets .multi_oplog
+  - name: replica_sets_multi_stmt_txn_jscore_passthrough
+  - name: replica_sets_multi_stmt_txn_stepdown_jscore_passthrough_gen
+    distros:
+    - rhel80-medium
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: rollback_fuzzer_gen
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: sharded_multi_stmt_txn_jscore_passthrough
+    distros:
+    - rhel80-medium
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.multiversion !.csrs
+  - name: snmp
+  - name: .ssl
+  - name: .updatefuzzer
+
+- name: linux-64-ephemeralForTest
+  display_name: Linux (ephemeralForTest)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - rhel80-medium
+  expansions:
+    # Transactions are not explicitly supported on the ephemeralForTest storage engine.
+    # Speculative majority reads are currently only allowed for change streams, which are only supported on WiredTiger.
+    # We also relax oplog constraints so that applying oplog entries after a rollbackViaRefetch works correctly.
+    # TODO (SERVER-47022): Re-enable oplog constraint enforcement once we set the application mode
+    # correctly after rollbackViaRefetch.
+    test_flags: >-
+      --storageEngine=ephemeralForTest
+      --excludeWithAnyTags=requires_persistence,requires_fsync,requires_journaling,requires_wiredtiger,uses_transactions,uses_speculative_majority,requires_snapshot_read,requires_majority_read_concern,uses_change_streams,requires_sharding,incompatible_with_eft
+      --mongodSetParameters="{oplogApplicationEnforcesSteadyStateConstraints: false}"
+    compile_flags: -j$(grep -c ^processor /proc/cpuinfo) --dbg=off --opt=on --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: rhel80
+    multiversion_edition: targeted
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    # TODO (SERVER-58125): Re-enable the timeseries fuzzer for EFT
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common !.timeseries # Disabled for FCV 5.3
+  - name: aggregation
+  - name: .auth !.multiversion !.audit !.sharding
+  # SERVER-58597: Re-enable parallel
+  - name: .misc_js !.parallel
+  # SERVER-50296: Investigate concurrency test failures.
+  # - name: concurrency_gen
+  # - name: concurrency_replication_gen
+  # - name: concurrency_replication_causal_consistency_gen
+  # - name: concurrency_simultaneous_gen
+  # - name: concurrency_simultaneous_replication
+  - name: .integration !.audit
+  - name: .jscore .common !.txns !.decimal
+  # SERVER-50295: Investigate jstestfuzz time outs.
+  # - name: .jstestfuzz .common
+  # SERVER-59095: Investigate the EFT failure and re-enable the failing jstest suite on evergreen.
+  # - name: .logical_session_cache .one_sec
+  - name: logical_session_cache_sharding_1sec_refresh_jscore_passthrough_gen
+  - name: logical_session_cache_standalone_1sec_refresh_jscore_passthrough_gen
+  - name: .read_write_concern .linearize
+  - name: replica_sets_gen
+  - name: .replica_sets .common
+  # SERVER-49428: Disabled due to writeConcernMajorityJournalDefault is not off
+  # rollback_fuzzer_gen
+  - name: .updatefuzzer
+
+
+###########################################
+#     Experimental buildvariants          #
+###########################################
+
+- &ubuntu1804-debug-asan-template
+  name: ubuntu1804-debug-asan
+  display_name: ~ ASAN Enterprise Ubuntu 18.04 DEBUG
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=address --ssl --ocsp-stapling=off --enable-free-mon=on -j$(grep -c ^processor /proc/cpuinfo)
+    test_flags: --excludeWithAnyTags=requires_fast_memory,requires_ocsp_stapling
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under ASAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    exec_timeout_secs: 14400 # 3 hour timeout
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_benchmarks
+  - name: build_variant_gen
+  - name: .aggregation
+  - name: .auth
+  - name: audit
+  - name: .benchmarks
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams
+  - name: .misc_js
+  - name: .concurrency !.ubsan !.no_txns !.kill_terminate
+  - name: .encrypt
+  - name: free_monitoring
+  - name: external_auth
+  - name: external_auth_aws
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.standalone !.audit
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .logical_session_cache
+  - name: .multi_shard .common
+  - name: multiversion_gen
+  - name: .multiversion_fuzzer
+  - name: .multiversion_passthrough
+  - name: .query_fuzzer
+  - name: .random_multiversion_ds
+  - name: .read_write_concern
+  - name: replica_sets_large_txns_format_gen
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: .replica_sets !.multi_oplog
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: .updatefuzzer
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: .sharding .common !.csrs
+  - name: snmp
+  - name: .watchdog
+  - name: .stitch
+  - name: .serverless
+  - name: unittest_shell_hang_analyzer_gen
+  - name: .updatefuzzer
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+
+- <<: *ubuntu1804-debug-asan-template
+  name: ubuntu1804-debug-asan-all-feature-flags
+  display_name: "~ Shared Library ASAN Enterprise Ubuntu 18.04 DEBUG (all feature flags)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=address --ssl --ocsp-stapling=off --enable-free-mon=on -j$(grep -c ^processor /proc/cpuinfo)
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under ASAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    exec_timeout_secs: 14400 # 3 hour timeout
+    # To force disable feature flags even on the all feature flags variant, please use this file:
+    # buildscripts/resmokeconfig/fully_disabled_feature_flags.yml
+    test_flags: >-
+        --runAllFeatureFlagTests
+        --excludeWithAnyTags=incompatible_with_shard_merge
+    separate_debug: off
+  tasks:
+  - name: change_streams_per_shard_cursor_passthrough
+  - name: cqf
+  - name: cqf_parallel
+  - name: compile_and_archive_dist_test_then_package_TG
+  - name: compile_benchmarks
+  - name: build_variant_gen
+  - name: .aggregation
+#  - name: .auth
+  - name: audit
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams
+  - name: .misc_js
+#  - name: .concurrency !.ubsan !.no_txns !.kill_terminate
+#  - name: .encrypt
+  - name: free_monitoring
+  - name: external_auth
+  - name: external_auth_aws
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.standalone !.audit
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .logical_session_cache
+  - name: .multi_shard .common
+  - name: .query_fuzzer
+  - name: .read_write_concern
+  - name: replica_sets_large_txns_format_gen
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: .replica_sets !.multi_oplog
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: .sharding .common !.csrs
+  - name: snmp
+  - name: .serverless
+  - name: .watchdog
+  - name: .stitch
+# Disabling the following tests as they are not aware of feature flags.
+#  - name: .benchmarks
+#  - name: unittest_shell_hang_analyzer_gen
+#  - name: server_discovery_and_monitoring_json_test_TG
+#  - name: server_selection_json_test_TG
+
+- <<: *ubuntu1804-debug-asan-template
+  name: ubuntu1804-debug-asan-classic-engine
+  display_name: ~ ASAN Enterprise Ubuntu 18.04 DEBUG (Classic Engine)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=address --ssl --ocsp-stapling=off --enable-free-mon=on -j$(grep -c ^processor /proc/cpuinfo)
+    test_flags: >-
+      --mongodSetParameters="{internalQueryForceClassicEngine: true}"
+      --excludeWithAnyTags=requires_fast_memory,requires_ocsp_stapling
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under ASAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    exec_timeout_secs: 14400 # 3 hour timeout
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_benchmarks
+  - name: build_variant_gen
+  - name: .aggregation
+  - name: .auth
+  - name: audit
+  - name: .benchmarks
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams
+  - name: .misc_js
+  - name: .concurrency !.ubsan !.no_txns !.kill_terminate
+  - name: .encrypt
+  - name: free_monitoring
+  - name: external_auth
+  - name: external_auth_aws
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.standalone !.audit
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .logical_session_cache
+  - name: .multi_shard .common
+  - name: .query_fuzzer
+  - name: .read_write_concern
+  - name: replica_sets_large_txns_format_gen
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: .replica_sets !.multi_oplog
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: .read_only
+  - name: .rollbackfuzzer
+  - name: .updatefuzzer
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: .sharding .common !.csrs
+  - name: snmp
+  - name: .watchdog
+  - name: .stitch
+  - name: .serverless
+  - name: unittest_shell_hang_analyzer_gen
+  - name: .updatefuzzer
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+
+- name: ubuntu1804-asan
+  display_name: ~ ASAN Ubuntu 18.04
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1804-build
+  stepback: true
+  expansions:
+    lang_environment: LANG=C
+    san_options: LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --opt=on --allocator=system --sanitize=address --ssl --ocsp-stapling=off -j$(grep -c ^processor /proc/cpuinfo)
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under ASAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    test_flags: --excludeWithAnyTags=requires_fast_memory,requires_ocsp_stapling
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: build_variant_gen
+#  - name: .aggfuzzer .common # Disabled for FCV 5.3
+  - name: free_monitoring
+  - name: .jstestfuzz !.initsync
+
+- &ubuntu1804-debug-ubsan-template
+  name: ubuntu1804-debug-ubsan
+  display_name: ~ UBSAN Enterprise Ubuntu 18.04 DEBUG
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: UBSAN_OPTIONS="print_stacktrace=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --sanitize=undefined --ssl --ocsp-stapling=off --enable-free-mon=on -j$(grep -c ^processor /proc/cpuinfo)
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under UBSAN build.
+    scons_cache_scope: shared
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_benchmarks
+  - name: build_variant_gen
+  - name: .aggregation
+  - name: .auth
+  - name: audit
+  - name: .benchmarks
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams
+  - name: .misc_js
+  - name: .concurrency !.no_txns !.repl !.kill_terminate
+  - name: disk_wiredtiger
+  - name: .encrypt
+  - name: free_monitoring
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .logical_session_cache .one_sec
+  - name: .multi_shard .common
+  - name: multiversion_gen
+  - name: .multiversion_fuzzer
+  - name: .multiversion_passthrough
+  - name: .random_multiversion_ds
+  - name: .read_write_concern
+  - name: replica_sets_large_txns_format_gen
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: .replica_sets !.multi_oplog
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: .rollbackfuzzer
+  - name: .read_only
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: .sharding .common !.csrs
+  - name: snmp
+  - name: .stitch
+  - name: .updatefuzzer
+  - name: .serverless
+  - name: watchdog_wiredtiger
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+
+- <<: *ubuntu1804-debug-ubsan-template
+  name: ubuntu1804-debug-ubsan-all-feature-flags
+  display_name: "~ Shared Library UBSAN Enterprise Ubuntu 18.04 DEBUG (all feature flags)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: UBSAN_OPTIONS="print_stacktrace=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --sanitize=undefined --ssl --ocsp-stapling=off --enable-free-mon=on -j$(grep -c ^processor /proc/cpuinfo)
+    # To force disable feature flags even on the all feature flags variant, please use this file:
+    # buildscripts/resmokeconfig/fully_disabled_feature_flags.yml
+    test_flags: >-
+        --excludeWithAnyTags=requires_ocsp_stapling
+        --excludeWithAnyTags=incompatible_with_shard_merge
+        --runAllFeatureFlagTests
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under UBSAN build.
+    scons_cache_scope: shared
+    separate_debug: off
+  tasks:
+  - name: change_streams_per_shard_cursor_passthrough
+  - name: cqf
+  - name: cqf_parallel
+  - name: compile_and_archive_dist_test_then_package_TG
+  - name: compile_benchmarks
+  - name: build_variant_gen
+  - name: .aggregation
+  - name: .auth
+  - name: audit
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams
+  - name: .misc_js
+  - name: .concurrency !.no_txns !.repl !.kill_terminate
+  - name: disk_wiredtiger
+  - name: .encrypt
+  - name: free_monitoring
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .logical_session_cache .one_sec
+  - name: .multi_shard .common
+  - name: .read_write_concern
+  - name: replica_sets_large_txns_format_gen
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: .replica_sets !.multi_oplog
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: .rollbackfuzzer
+  - name: .read_only
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: .sharding .common !.csrs
+  - name: snmp
+  - name: .stitch
+  - name: .serverless
+  - name: .updatefuzzer
+  - name: watchdog_wiredtiger
+# Disabling the following tests as they are not aware of feature flags.
+#  - name: .benchmarks
+#  - name: server_discovery_and_monitoring_json_test_TG
+#  - name: server_selection_json_test_TG
+
+- <<: *ubuntu1804-debug-ubsan-template
+  name: ubuntu1804-debug-ubsan-classic-engine
+  display_name: ~ UBSAN Enterprise Ubuntu 18.04 DEBUG (Classic Engine)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: UBSAN_OPTIONS="print_stacktrace=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --sanitize=undefined --ssl --ocsp-stapling=off --enable-free-mon=on -j$(grep -c ^processor /proc/cpuinfo)
+    test_flags: >-
+      --mongodSetParameters="{internalQueryForceClassicEngine: true}"
+      --excludeWithAnyTags=requires_ocsp_stapling
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under UBSAN build.
+    scons_cache_scope: shared
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_serial_TG
+  - name: compile_benchmarks
+  - name: build_variant_gen
+  - name: .aggregation
+  - name: .auth
+  - name: audit
+  - name: .benchmarks
+  - name: .causally_consistent !.wo_snapshot
+  - name: .change_streams
+  - name: .misc_js
+  - name: .concurrency !.no_txns !.repl !.kill_terminate
+  - name: disk_wiredtiger
+  - name: .encrypt
+  - name: free_monitoring
+  - name: initial_sync_fuzzer_gen
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: jsCore_minimum_batch_size
+  - name: jsCore_txns_large_txns_format
+  - name: json_schema
+  - name: .logical_session_cache .one_sec
+  - name: .multi_shard .common
+  - name: .read_write_concern
+  - name: replica_sets_large_txns_format_gen
+  - name: replica_sets_large_txns_format_jscore_passthrough
+  - name: .replica_sets !.multi_oplog
+  - name: .resharding_fuzzer
+  - name: .retry
+  - name: .rollbackfuzzer
+  - name: .read_only
+  - name: sasl
+  - name: secondary_reads_passthrough_gen
+  - name: session_jscore_passthrough
+  - name: .sharding .jscore !.wo_snapshot
+  - name: .sharding .common !.csrs
+  - name: snmp
+  - name: .stitch
+  - name: .updatefuzzer
+  - name: .serverless
+  - name: watchdog_wiredtiger
+  - name: server_discovery_and_monitoring_json_test_TG
+  - name: server_selection_json_test_TG
+
+- &ubuntu1804-debug-aubsan-lite-required-template
+  name: ubuntu1804-debug-aubsan-lite-required
+  display_name: "! Shared Library {A,UB}SAN Enterprise Ubuntu 18.04 DEBUG"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: true
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: UBSAN_OPTIONS="print_stacktrace=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=undefined,address --ssl --ocsp-stapling=off -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under {A,UB}SAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    max_sub_suites: 3
+    num_scons_link_jobs_available: 0.99
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: build_variant_gen
+  - name: jsCore
+  - name: jsCore_txns
+  - name: unittest_shell_hang_analyzer_gen
+
+- <<: *ubuntu1804-debug-aubsan-lite-required-template
+  name: ubuntu1804-debug-aubsan-lite-all-feature-flags-required
+  display_name: "! Shared Library {A,UB}SAN Enterprise Ubuntu 18.04 DEBUG (all feature flags)"
+  cron: "0 */4 * * *" # Every 4 hours starting at midnight
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: UBSAN_OPTIONS="print_stacktrace=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=undefined,address --ssl --ocsp-stapling=off -j$(grep -c ^processor /proc/cpuinfo) --link-model=dynamic
+    # To force disable feature flags even on the all feature flags variant, please use this file:
+    # buildscripts/resmokeconfig/fully_disabled_feature_flags.yml
+    test_flags: >-
+        --excludeWithAnyTags=requires_ocsp_stapling
+        --excludeWithAnyTags=incompatible_with_shard_merge
+        --runAllFeatureFlagTests
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under {A,UB}SAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+    max_sub_suites: 3
+    num_scons_link_jobs_available: 0.99
+    separate_debug: off
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - ubuntu1804-xlarge
+  - name: build_variant_gen
+  - name: jsCore
+  - name: jsCore_txns
+# Disabling these tests as they are not aware of feature flags.
+#  - name: compile_test_and_package_parallel_unittest_stream_TG
+#    distros:
+#      - ubuntu1804-xlarge
+#  - name: compile_test_and_package_parallel_dbtest_stream_TG
+#    distros:
+#      - ubuntu1804-xlarge
+#  - name: unittest_shell_hang_analyzer_gen
+
+- name: ubuntu1804-debug-aubsan-lite_fuzzer
+  display_name: "{A,UB}SAN Enterprise Ubuntu 18.04 FUZZER"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-build
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate changes are
+    # also made to SConstruct.
+    san_options: UBSAN_OPTIONS="print_stacktrace=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer" LSAN_OPTIONS="suppressions=etc/lsan.suppressions:report_objects=1" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=true:strict_init_order=true:abort_on_error=1:disable_coredump=0:handle_abort=1:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    compile_flags: LINKFLAGS=-nostdlib++ LIBS=stdc++ --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=undefined,address,fuzzer --ssl --ocsp-stapling=off -j$(grep -c ^processor /proc/cpuinfo)
+    test_flags: --excludeWithAnyTags=requires_ocsp_stapling
+    resmoke_jobs_factor: 0.3  # Avoid starting too many mongod's under {A,UB}SAN build.
+    hang_analyzer_dump_core: false
+    scons_cache_scope: shared
+    separate_debug: off
+  display_tasks:
+  - *libfuzzertests
+  tasks:
+   - name: compile_archive_and_run_libfuzzertests_TG
+
+- name: enterprise-ubuntu2004-debug-tsan
+  display_name: ~ TSAN Enterprise Ubuntu 20.04 DEBUG (ephemeralForTest)
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+    - enterprise
+  run_on:
+    - ubuntu2004-large
+  stepback: false
+  expansions:
+    additional_package_targets: archive-mongocryptd archive-mongocryptd-debug
+    lang_environment: LANG=C
+    # If you add anything to san_options, make sure the appropriate
+    # changes are also made to SConstruct.
+    #
+    # TODO SERVER-49121: die_after_fork=0 is a temporary setting to
+    # allow tests to continue while we figure out why we're running
+    # afoul of it.
+    #
+    # TODO SERVER-52413: report_thread_leaks=0 suppresses reporting
+    # thread leaks, which we have because we don't do a clean shutdown
+    # of the ServiceContext.
+    #
+    san_options: TSAN_OPTIONS="halt_on_error=1:report_thread_leaks=0:die_after_fork=0:suppressions=etc/tsan.suppressions:external_symbolizer_path=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+    # TODO: Remove some of the excluded tags when the ephemeralForTest storage engine is
+    # further along in development: https://jira.mongodb.org/browse/SERVER-48325
+    test_flags: --storageEngine=ephemeralForTest --excludeWithAnyTags=requires_persistence,requires_journaling,uses_transactions,requires_wiredtiger,requires_snapshot_read,requires_majority_read_concern
+    compile_flags: --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars --dbg=on --opt=on --allocator=system --sanitize=thread --ssl --enable-free-mon=on --use-libunwind=off -j$(grep -c ^processor /proc/cpuinfo)
+    # Avoid starting too many mongod's under TSAN build.
+    resmoke_jobs_factor: 0.3
+    scons_cache_scope: shared
+    separate_debug: off
+  tasks:
+    - name: compile_test_and_package_serial_TG
+    - name: jsCore
+
+- name: enterprise-ubuntu-unoptimized-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (without Diagnostic Latches)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  expansions:
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --use-diagnostic-latches=off
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+
+- name: enterprise-ubuntu-no-latch-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 DEBUG (Unoptimized)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  modules:
+  - enterprise
+  expansions:
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --dbg=on --opt=off --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --detect-odr-violations
+    scons_cache_scope: shared
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+
+- name: enterprise-ubuntu-fixed-service-executor-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (with FixedServiceExecutor)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+    - ubuntu1804-test
+  modules:
+  - enterprise
+  expansions:
+    scons_cache_scope: shared
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: >-
+      --mongosSetParameters="{initialServiceExecutorThreadingModel: borrowed}"
+      --mongodSetParameters="{initialServiceExecutorThreadingModel: borrowed}"
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .aggregation !.no_async
+  - name: .sharding .auth
+  - name: .sharding .causally_consistent !.wo_snapshot
+  - name: .concurrency .common !.kill_terminate
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: noPassthrough_gen
+  - name: noPassthroughWithMongod_gen
+  - name: .logical_session_cache .one_sec
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+
+- name: enterprise-ubuntu-sdam-replica-set-monitor-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (with SdamReplicaSetMonitor)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+    - ubuntu1804-test
+  modules:
+  - enterprise
+  expansions:
+    scons_cache_scope: shared
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: >-
+      --mongosSetParameters="{replicaSetMonitorProtocol: sdam}"
+      --mongodSetParameters="{replicaSetMonitorProtocol: sdam}"
+      --excludeWithAnyTags=requires_streamable_rsm
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .aggregation !.no_async
+  - name: .sharding .auth
+  - name: .sharding .causally_consistent !.wo_snapshot
+  - name: .concurrency .common !.kill_terminate
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: .logical_session_cache .one_sec
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+
+- name: enterprise-ubuntu-task-executor-pool-size-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (with {taskExecutorPoolSize: 4})"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+    - ubuntu1804-test
+  modules:
+  - enterprise
+  expansions:
+    scons_cache_scope: shared
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: |- # Set the taskExecutorPoolSize for all tests
+        --mongosSetParameters="taskExecutorPoolSize: 4"
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .aggregation !.no_async
+  - name: .sharding .auth
+  - name: .sharding .causally_consistent !.wo_snapshot
+  - name: .concurrency .common !.kill_terminate
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: .logical_session_cache .one_sec
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+
+- name: enterprise-ubuntu-sharding-task-executor-pool-rsm-matchPrimary-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (with {ShardingTaskExecutorPoolReplicaSetMatching: \"matchPrimaryNode\"})"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+    - ubuntu1804-test
+  modules:
+  - enterprise
+  expansions:
+    scons_cache_scope: shared
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: >-
+        --mongosSetParameters="ShardingTaskExecutorPoolReplicaSetMatching: \"matchPrimaryNode\""
+        --excludeWithAnyTags=sets_replica_set_matching_strategy
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .aggregation !.no_async
+  - name: .sharding .auth
+  - name: .sharding .causally_consistent !.wo_snapshot
+  - name: .concurrency .common !.kill_terminate
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: .logical_session_cache .one_sec
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+
+- name: enterprise-ubuntu-sharding-task-executor-pool-rsm-matchBusiest-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (with {ShardingTaskExecutorPoolReplicaSetMatching: \"matchBusiestNode\"})"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+    - ubuntu1804-test
+  modules:
+  - enterprise
+  expansions:
+    scons_cache_scope: shared
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: >-
+        --mongosSetParameters="ShardingTaskExecutorPoolReplicaSetMatching: \"matchBusiestNode\""
+        --excludeWithAnyTags=sets_replica_set_matching_strategy
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .aggregation !.no_async
+  - name: .sharding .auth
+  - name: .sharding .causally_consistent !.wo_snapshot
+  - name: .concurrency .common !.kill_terminate
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: .logical_session_cache .one_sec
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+
+- name: enterprise-ubuntu-sharding-task-executor-pool-rsm-disabled-1804-64-bit
+  display_name: "~ Enterprise Ubuntu 18.04 (with {ShardingTaskExecutorPoolReplicaSetMatching: \"disabled\"})"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+    - ubuntu1804-test
+  modules:
+  - enterprise
+  expansions:
+    scons_cache_scope: shared
+    compile_flags: MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    test_flags: >-
+        --mongosSetParameters="ShardingTaskExecutorPoolReplicaSetMatching: \"disabled\""
+        --excludeWithAnyTags=sets_replica_set_matching_strategy
+    large_distro_name: ubuntu1804-build
+  tasks:
+  - name: compile_test_and_package_serial_TG
+    distros:
+    - ubuntu1804-build
+  - name: build_variant_gen
+  - name: .aggregation !.no_async
+  - name: .sharding .auth
+  - name: .sharding .causally_consistent !.wo_snapshot
+  - name: .concurrency .common !.kill_terminate
+  - name: .integration !.audit
+  - name: .jscore .common
+  - name: .logical_session_cache .one_sec
+  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+  - name: .sharding .common !.csrs
+
+- name: shared-scons-cache-pruning
+  display_name: "Shared SCons Cache Pruning"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - ubuntu1604-test
+  stepback: false
+  tasks:
+  - name: shared_scons_cache_pruning
+
+- name: windows-shared-scons-cache-pruning
+  display_name: "Windows shared SCons Cache Pruning"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  run_on:
+  - windows-vsCurrent-small
+  stepback: false
+  expansions:
+    python: '/cygdrive/c/python/python37/python.exe'
+  tasks:
+  - name: win_shared_scons_cache_pruning
+
+- name: selected-tests
+  display_name: "~ Selected Tests"
+  modules:
+    - enterprise
+  run_on:
+    - rhel80-small
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  stepback: false
+  expansions:
+    selected_tests_buildvariants: enterprise-windows-required linux-64-debug-required enterprise-ubuntu-dynamic-1604-clang ubuntu1804-debug-aubsan-lite-required
+  tasks:
+  - name: selected_tests_gen
+
+- <<: *enterprise-rhel-80-64-bit-dynamic-required-template
+  name: commit-queue
+  display_name: "~ Commit Queue"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday
+  stepback: false
+  tasks:
+  - name: compile_test_and_package_parallel_core_stream_TG
+    distros:
+      - rhel80-xlarge-commitqueue
+  - name: compile_test_and_package_parallel_unittest_stream_TG
+    distros:
+      - rhel80-xlarge-commitqueue
+  - name: compile_test_and_package_parallel_dbtest_stream_TG
+    distros:
+      - rhel80-xlarge-commitqueue
+  - name: jsCore
+    distros:
+      - rhel80-xlarge-commitqueue
+  - name: .lint
+  - name: test_api_version_compatibility
+  - name: validate_commit_message
+  - name: check_feature_flag_tags
+
+#- name: live-record
+#  display_name: "~ RHEL 8.0 Shared Library (with UndoDB live-record)"
+#  cron: "0 12 * * *" # Every day starting at 12:00
+#  stepback: false
+#  modules:
+#  - enterprise
+#  run_on:
+#  - rhel80-medium
+#  expansions:
+#    compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+#    multiversion_platform: rhel80
+#    multiversion_edition: enterprise
+#    has_packages: false
+#    scons_cache_scope: shared
+#    scons_cache_mode: all
+#    target_resmoke_time: 10
+#    max_sub_suites: 3
+#    large_distro_name: rhel80-medium
+#    num_scons_link_jobs_available: 0.99
+#    record_with: --recordWith /opt/undodb5/bin/live-record
+#    resmoke_jobs_factor: 0.3
+#    exec_timeout_secs: 28800 # 8 hours
+#    test_flags: --excludeWithAnyTags=requires_fast_memory,live_record_incompatible
+#  tasks:
+#  - name: compile_and_archive_dist_test_TG
+#  - name: build_variant_gen
+##  - name: .aggfuzzer # Disabled for FCV 5.3
+#  - name: .aggregation
+##  - name: audit
+##  - name: .auth !.multiversion !.non_live_record
+##  - name: .causally_consistent !.sharding
+##  - name: .change_streams
+##  - name: .misc_js !.non_live_record
+#  - name: .concurrency !.ubsan !.no_txns !.debug_only !.stepdowns !.non_live_record !.large
+##  - name: .encrypt
+##  - name: initial_sync_fuzzer_gen
+#  - name: .jscore .common
+##  - name: jsCore_minimum_batch_size
+#  - name: jsCore_txns_large_txns_format
+##  - name: json_schema
+#  - name: .jstestfuzz !.flow_control !.stepdowns !.causal
+##  - name: .multiversion_sanity_check
+##  - name: mqlrun
+##  - name: .multi_shard
+##  - name: .query_fuzzer
+##  - name: .read_write_concern
+##  - name: .replica_sets !.encrypt !.auth !.non_live_record
+##  - name: replica_sets_reconfig_jscore_passthrough_gen
+##  - name: replica_sets_reconfig_jscore_stepdown_passthrough_gen
+#  - name: retryable_writes_jscore_passthrough_gen
+#  - name: retryable_writes_jscore_stepdown_passthrough_gen
+##  - name: .read_only
+##  - name: .rollbackfuzzer
+#  - name: sasl
+##  - name: search
+##  - name: search_auth
+##  - name: search_ssl
+##  - name: session_jscore_passthrough
+#  - name: .sharding .jscore !.wo_snapshot !.multi_stmt
+##  - name: .sharding .txns
+##  - name: .sharding .common !.non_live_record
+#  - name: snmp
+##  - name: .updatefuzzer
+
+- name: windows-dynamic-visibility-test
+  display_name: "~ Shared Library Windows (visibility test)"
+  cron: "0 12 * * *" # Every day starting at 12:00
+  expansions:
+    compile_flags: CPPPATH="c:/sasl/include c:/snmp/include" LIBPATH="c:/sasl/lib c:/snmp/lib" -j$(( $(grep -c ^processor /proc/cpuinfo) / 2 )) --win-version-min=win10
+    python: '/cygdrive/c/python/python37/python.exe'
+    ext: zip
+    has_packages: false
+    scons_cache_scope: shared
+    scons_cache_mode: all
+  tasks:
+  - name: visibility_test_TG
+    distros:
+    - windows-vsCurrent-large
+
+### QO & QE Patch-Specific Build Variants ###
+- <<: *enterprise-windows-nopush-template
+  name: windows-compile-query-patch-only
+  display_name: "~ Windows Compile Query Patch Only"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday . This is a patch-only variant but we run on mainline to pick up task history.
+  tasks:
+  - name: compile_dist_test_TG
+    distros:
+    - windows-vsCurrent-large
+
+### QO & QE Patch-Specific Build Variants ###
+- <<: *enterprise-rhel-80-64-bit-dynamic-classic-engine
+  name: enterprise-rhel-80-64-bit-dynamic-classic-engine-query-patch-only
+  display_name: "~ Shared Library Enterprise RHEL 8.0 Query Patch Only (Classic Engine)"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday . This is a patch-only variant but we run on mainline to pick up task history.
+  expansions:
+    <<: *enterprise-rhel-80-64-bit-dynamic-classic-engine-expansions
+    jstestfuzz_num_generated_files: 20
+    jstestfuzz_concurrent_num_files: 5
+    target_resmoke_time: 30
+    max_sub_suites: 3
+    test_flags: >-
+      --mongodSetParameters="{internalQueryForceClassicEngine: true}"
+      --excludeWithAnyTags=resource_intensive
+
+# Intentionally derive from SBE to run the SBE tests with all feature flags.
+- <<: *enterprise-rhel-80-64-bit-dynamic-all-feature-flags-required-template
+  name: enterprise-rhel-80-64-bit-dynamic-all-feature-flags-required-query-patch-only
+  display_name: "~ Shared Library Enterprise RHEL 8.0 Query Patch Only (all feature flags)"
+  cron: "0 0 * * 0" # Every week starting 00:00 on Sunday . This is a patch-only variant but we run on mainline to pick up task history.
+  expansions:
+    <<: *enterprise-rhel-80-64-bit-dynamic-all-feature-flags-expansions
+    jstestfuzz_num_generated_files: 20
+    jstestfuzz_concurrent_num_files: 5
+    target_resmoke_time: 30
+    max_sub_suites: 3
+    test_flags: >-
+      --runAllFeatureFlagTests
+      --excludeWithAnyTags=resource_intensive
+      --excludeWithAnyTags=incompatible_with_shard_merge
+
+- name: enterprise-ubuntu1804-64-libvoidstar
+  display_name: ~ Enterprise Ubuntu 18.04 w/ libvoidstar
+  cron: "0 0 * * FRI" # Every week starting 00:00 on Friday
+  modules:
+  - enterprise
+  run_on:
+  - ubuntu1804-large
+  stepback: false
+  expansions:
+    compile_flags: --ssl --ocsp-stapling=off MONGO_DISTMOD=ubuntu1804 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_clang.vars CCFLAGS="-fsanitize-coverage=trace-pc-guard" LIBS="voidstar"
+    multiversion_platform: ubuntu1804
+    multiversion_edition: enterprise
+    repo_edition: enterprise
+    large_distro_name: ubuntu1804-build
+    use_scons_cache: false
+    scons_cache_scope: "none"
+  tasks:
+  - name: compile_and_archive_dist_test_TG
+  - name: .antithesis
+  - name: generate_buildid_to_debug_symbols_mapping

--- a/tests/data/sample_evergreen_auth.yml
+++ b/tests/data/sample_evergreen_auth.yml
@@ -1,0 +1,3 @@
+user: my.user.name
+api_key: myApiKey
+api_server_host: https://evergreen.mongodb.com/api

--- a/tests/data/sample_expansions.yml
+++ b/tests/data/sample_expansions.yml
@@ -1,0 +1,3 @@
+project: mongodb-mongo-master
+revision: abc123
+version_id: version_def456

--- a/tests/data/tests/test_0.js
+++ b/tests/data/tests/test_0.js
@@ -1,0 +1,1 @@
+fake test 0

--- a/tests/data/tests/test_1.js
+++ b/tests/data/tests/test_1.js
@@ -1,0 +1,1 @@
+fake test 1

--- a/tests/data/tests/test_10.js
+++ b/tests/data/tests/test_10.js
@@ -1,0 +1,1 @@
+fake test 10

--- a/tests/data/tests/test_11.js
+++ b/tests/data/tests/test_11.js
@@ -1,0 +1,1 @@
+fake test 11

--- a/tests/data/tests/test_12.js
+++ b/tests/data/tests/test_12.js
@@ -1,0 +1,1 @@
+fake test 12

--- a/tests/data/tests/test_13.js
+++ b/tests/data/tests/test_13.js
@@ -1,0 +1,1 @@
+fake test 13

--- a/tests/data/tests/test_14.js
+++ b/tests/data/tests/test_14.js
@@ -1,0 +1,1 @@
+fake test 14

--- a/tests/data/tests/test_2.js
+++ b/tests/data/tests/test_2.js
@@ -1,0 +1,1 @@
+fake test 2

--- a/tests/data/tests/test_3.js
+++ b/tests/data/tests/test_3.js
@@ -1,0 +1,1 @@
+fake test 3

--- a/tests/data/tests/test_4.js
+++ b/tests/data/tests/test_4.js
@@ -1,0 +1,1 @@
+fake test 4

--- a/tests/data/tests/test_5.js
+++ b/tests/data/tests/test_5.js
@@ -1,0 +1,1 @@
+fake test 5

--- a/tests/data/tests/test_6.js
+++ b/tests/data/tests/test_6.js
@@ -1,0 +1,1 @@
+fake test 6

--- a/tests/data/tests/test_7.js
+++ b/tests/data/tests/test_7.js
@@ -1,0 +1,1 @@
+fake test 7

--- a/tests/data/tests/test_8.js
+++ b/tests/data/tests/test_8.js
@@ -1,0 +1,1 @@
+fake test 8

--- a/tests/data/tests/test_9.js
+++ b/tests/data/tests/test_9.js
@@ -1,0 +1,1 @@
+fake test 9

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,30 @@
+use assert_cmd::Command;
+use tempdir::TempDir;
+
+#[test]
+fn test_end2end_execution() {
+    let mut cmd = Command::cargo_bin("mongo-task-generator").unwrap();
+    let tmp_dir = TempDir::new("generated_resmoke_config").unwrap();
+
+    cmd.args(&[
+        "--target-directory",
+        tmp_dir.path().to_str().unwrap(),
+        "--expansion-file",
+        "tests/data/sample_expansions.yml",
+        "--evg-project-file",
+        "tests/data/evergreen.yml",
+        "--evg-auth-file",
+        "tests/data/sample_evergreen_auth.yml",
+        "--resmoke-command",
+        "python3 tests/mocks/resmoke.py",
+        "--use-task-split-fallback",
+    ])
+    .assert()
+    .success();
+
+    let tmp_dir_path = tmp_dir.path();
+    assert!(tmp_dir_path.exists());
+
+    let files = std::fs::read_dir(tmp_dir_path).unwrap();
+    assert_eq!(1111, files.into_iter().collect::<Vec<_>>().len());
+}

--- a/tests/mocks/resmoke.py
+++ b/tests/mocks/resmoke.py
@@ -1,0 +1,59 @@
+"""Mock of resmoke.py for testing task generation."""
+import sys
+
+
+def multiversion_config():
+    print("""
+last_versions:
+- last_lts
+- last_continuous
+requires_fcv_tag: requires_fcv_51,requires_fcv_52,requires_fcv_53,requires_fcv_60
+    """)
+
+
+def suiteconfig():
+    print("""
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/auth/*.js
+  exclude_files:
+    - jstests/auth/repl.js
+
+executor:
+  config:
+    shell_options:
+      global_vars:
+        TestData:
+          roleGraphInvalidationIsFatal: true
+      nodb: ''
+  fixture:
+    class: ReplicaSetFixture
+    num_nodes: 3
+    """)
+
+
+def test_discovery():
+    test_list = "\n".join([f"- tests/data/tests/test_{test}.js" for test in range(15)])
+    print(f"""
+suite_name: my_suite
+tests:
+{test_list}
+    """)
+
+
+def main():
+    subcommand = sys.argv[1]
+    if subcommand == "multiversion-config":
+        multiversion_config()
+    elif subcommand == "suiteconfig":
+        suiteconfig()
+    elif subcommand == "test-discovery":
+        test_discovery()
+    else:
+        raise ValueError(f"Unknown subcommand: {subcommand}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds 2 new tests alongs with some infrastructure to mock some things out.

* The first test is an integration test that runs againsta snapshot of the server codebase's evergreen.yml and tries to generate all the configuration for it. 
* The second test uses a tool to make sure that the Cargo.toml version and the changelog have been updated (similar to what we do in other tools).