### PR TITLE
DAG-1928: Add support for generating burn_in_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.7 - 2022-07-13
+
+* Add support for burn_in_tags generation.
+
 ## 0.4.6 - 2022-07-01
 
 * Add support for burn_in_tests generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.7 - 2022-07-13
+## 0.4.7 - 2022-07-14
 
 * Add support for burn_in_tags generation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.4.6"
+version = "0.4.7"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ graph TD
     G --> |Yes| H[Split task by test runtimes]
     G --> |No| I[Split task by counts]
     H --> J[Generate resmoke suite config]
-    I -> J
+    I --> J
     J --> |generated task definitions|B
     B --> |done|K[For each Build Variant]
     K --> L[Create task specs and display tasks in Build Variant]

--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -34,6 +34,10 @@ pub const GENERATE_RESMOKE_TASKS: &str = "generate resmoke tasks";
 pub const GENERATOR_TASKS: &str = "generator_tasks";
 /// Name of burn_in_tests task.
 pub const BURN_IN_TESTS: &str = "burn_in_tests_gen";
+/// Name of burn_in_tags task.
+pub const BURN_IN_TAGS: &str = "burn_in_tags_gen";
+/// Name of compile task group.
+pub const COMPILE_TASK_GROUP_NAME: &str = "compile_and_archive_dist_test_TG";
 
 // Vars
 /// Variable that indicates a task is a fuzzer.
@@ -81,6 +85,10 @@ pub const MULTIVERSION_EXCLUDE_TAGS: &str = "multiversion_exclude_tags_version";
 // Build Variant expansions.
 /// Name of large distro for build variant.
 pub const LARGE_DISTRO_EXPANSION: &str = "large_distro_name";
+/// List of build variant names delimited by spaces to generate burn_in_tags for.
+pub const BURN_IN_TAG_BUILD_VARIANTS: &str = "burn_in_tag_buildvariants";
+/// Name of build variant to determine the timeouts for.
+pub const BURN_IN_BYPASS: &str = "burn_in_bypass";
 
 // Task Tags
 /// Tag to include multiversion setup is required.
@@ -99,3 +107,7 @@ pub const MULTIVERSION_EXCLUDE_TAGS_FILE: &str = "multiversion_exclude_tags.yml"
 pub const MULTIVERSION_LAST_LTS: &str = "last_lts";
 /// Name of last continuous configuration.
 pub const MULTIVERSION_LAST_CONTINUOUS: &str = "last_continuous";
+
+// Distros
+/// Name of compile task distro for burn_in_tags.
+pub const COMPILE_TASK_DISTRO: &str = "rhel80-xlarge";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ mod services;
 mod task_types;
 mod utils;
 
-/// Directory to store the generated configuration in.
+const BURN_IN_PREFIX: &str = "burn_in_tests";
 const HISTORY_LOOKBACK_DAYS: u64 = 14;
 const MAX_SUB_TASKS_PER_TASK: usize = 5;
 
@@ -615,7 +615,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 let generated_tasks = generated_tasks.lock().unwrap();
 
                 let task_name = if task.name == BURN_IN_TESTS {
-                    format!("burn_in_tests-{}", build_variant.name)
+                    format!("{}-{}", BURN_IN_PREFIX, build_variant.name)
                 } else {
                     lookup_task_name(is_enterprise, &task.name)
                 };
@@ -662,7 +662,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
             let generated_tasks = generated_tasks.lock().unwrap();
             let base_build_variant = build_variant_map.get(&base_bv_name).unwrap();
             let run_build_variant_name = format!("{}-required", base_build_variant.name);
-            let task_name = format!("burn_in_tests-{}", run_build_variant_name);
+            let task_name = format!("{}-{}", BURN_IN_PREFIX, run_build_variant_name);
 
             if let Some(generated_task) = generated_tasks.get(&task_name) {
                 generated_build_variants.push(
@@ -773,7 +773,7 @@ fn create_burn_in_worker(
             .generate_burn_in_suite(&build_variant.name, &run_build_variant_name, task_map)
             .unwrap();
 
-        let task_name = format!("burn_in_tests-{}", run_build_variant_name);
+        let task_name = format!("{}-{}", BURN_IN_PREFIX, run_build_variant_name);
 
         if !generated_task.sub_tasks().is_empty() {
             let mut generated_tasks = generated_tasks.lock().unwrap();
@@ -787,9 +787,15 @@ mod tests {
     use maplit::hashset;
     use rstest::rstest;
 
-    use crate::task_types::{
-        fuzzer_tasks::FuzzerGenTaskParams,
-        resmoke_tasks::{ResmokeGenParams, SubSuite},
+    use crate::{
+        resmoke::burn_in_proxy::{BurnInDiscovery, DiscoveredTask},
+        task_types::{
+            fuzzer_tasks::FuzzerGenTaskParams,
+            multiversion::{MultiversionIterator, MultiversionService},
+            resmoke_tasks::{
+                GeneratedResmokeSuite, ResmokeGenParams, ResmokeSuiteGenerationInfo, SubSuite,
+            },
+        },
     };
 
     use super::*;
@@ -937,6 +943,273 @@ mod tests {
         assert_eq!(
             lookup_task_name(is_enterprise, task_name),
             expected_task_name.to_string()
+        );
+    }
+
+    struct MockEvgConfigUtils {}
+    impl EvgConfigUtils for MockEvgConfigUtils {
+        fn is_task_generated(&self, _task: &EvgTask) -> bool {
+            todo!()
+        }
+
+        fn is_task_fuzzer(&self, _task: &EvgTask) -> bool {
+            todo!()
+        }
+
+        fn find_suite_name<'a>(&self, _task: &'a EvgTask) -> &'a str {
+            todo!()
+        }
+
+        fn get_task_tags(&self, _task: &EvgTask) -> HashSet<String> {
+            todo!()
+        }
+
+        fn get_task_dependencies(&self, _task: &EvgTask) -> Vec<String> {
+            todo!()
+        }
+
+        fn get_gen_task_var<'a>(&self, _task: &'a EvgTask, _var: &str) -> Option<&'a str> {
+            todo!()
+        }
+
+        fn get_gen_task_vars(
+            &self,
+            _task: &EvgTask,
+        ) -> Option<HashMap<String, shrub_rs::models::params::ParamValue>> {
+            todo!()
+        }
+
+        fn translate_run_var(
+            &self,
+            _run_var: &str,
+            _build_variantt: &BuildVariant,
+        ) -> Option<String> {
+            todo!()
+        }
+
+        fn lookup_build_variant_expansion(
+            &self,
+            _name: &str,
+            _build_variant: &BuildVariant,
+        ) -> Option<String> {
+            todo!()
+        }
+
+        fn lookup_and_split_by_whitespace_build_variant_expansion(
+            &self,
+            _name: &str,
+            _build_variant: &BuildVariant,
+        ) -> Vec<String> {
+            todo!()
+        }
+
+        fn lookup_required_param_str(
+            &self,
+            _task_def: &EvgTask,
+            _run_varr: &str,
+        ) -> Result<String> {
+            todo!()
+        }
+
+        fn lookup_required_param_u64(&self, _task_def: &EvgTask, _run_varr: &str) -> Result<u64> {
+            todo!()
+        }
+
+        fn lookup_required_param_bool(&self, _task_def: &EvgTask, _run_var: &str) -> Result<bool> {
+            todo!()
+        }
+
+        fn lookup_default_param_bool(
+            &self,
+            _task_def: &EvgTask,
+            _run_var: &str,
+            _default: bool,
+        ) -> Result<bool> {
+            todo!()
+        }
+
+        fn lookup_default_param_str(
+            &self,
+            _task_def: &EvgTask,
+            _run_var: &str,
+            _default: &str,
+        ) -> String {
+            todo!()
+        }
+
+        fn lookup_optional_param_u64(
+            &self,
+            _task_def: &EvgTask,
+            _run_var: &str,
+        ) -> Result<Option<u64>> {
+            todo!()
+        }
+
+        fn is_enterprise_build_variant(&self, _build_variant: &BuildVariant) -> bool {
+            todo!()
+        }
+    }
+
+    struct MockResmokeConfigActorService {}
+    #[async_trait]
+    impl ResmokeConfigActor for MockResmokeConfigActorService {
+        async fn write_sub_suite(&mut self, _gen_suite: &ResmokeSuiteGenerationInfo) {
+            todo!()
+        }
+
+        async fn flush(&mut self) -> Result<Vec<String>> {
+            todo!()
+        }
+    }
+
+    struct MockBurnInDiscovery {}
+    impl BurnInDiscovery for MockBurnInDiscovery {
+        fn discover_tasks(&self, _build_variant: &str) -> Result<Vec<DiscoveredTask>> {
+            todo!()
+        }
+    }
+
+    struct MockConfigExtractionService {}
+    impl ConfigExtractionService for MockConfigExtractionService {
+        fn task_def_to_fuzzer_params(
+            &self,
+            _task_def: &EvgTask,
+            _build_variant: &BuildVariant,
+        ) -> Result<FuzzerGenTaskParams> {
+            todo!()
+        }
+
+        fn task_def_to_resmoke_params(
+            &self,
+            _task_def: &EvgTask,
+            _is_enterprise: bool,
+        ) -> Result<ResmokeGenParams> {
+            todo!()
+        }
+    }
+
+    struct MockMultiversionService {}
+    impl MultiversionService for MockMultiversionService {
+        fn get_version_combinations(&self, _suite_name: &str) -> Result<Vec<String>> {
+            todo!()
+        }
+
+        fn multiversion_iter(&self, _suite_name: &str) -> Result<MultiversionIterator> {
+            todo!()
+        }
+
+        fn name_multiversion_suite(
+            &self,
+            _base_name: &str,
+            _old_version: &str,
+            _version_combination: &str,
+        ) -> String {
+            todo!()
+        }
+
+        fn exclude_tags_for_task(&self, _task_name: &str, _mv_mode: Option<String>) -> String {
+            todo!()
+        }
+    }
+
+    struct MockBurnInService {
+        sub_suites: Vec<EvgTask>,
+    }
+    impl BurnInService for MockBurnInService {
+        fn generate_burn_in_suite(
+            &self,
+            _build_variant: &str,
+            _run_build_variant_name: &str,
+            _task_map: Arc<HashMap<String, EvgTask>>,
+        ) -> Result<Box<dyn GeneratedSuite>> {
+            Ok(Box::new(GeneratedResmokeSuite {
+                task_name: "burn_in_tests".to_string(),
+                sub_suites: self.sub_suites.clone(),
+                use_large_distro: false,
+            }))
+        }
+
+        fn generate_burn_in_tags_build_variant(
+            &self,
+            _base_build_variant: &BuildVariant,
+            _run_build_variant_name: String,
+            _generated_task: &dyn GeneratedSuite,
+        ) -> BuildVariant {
+            todo!()
+        }
+    }
+
+    fn build_mocked_burn_in_service(sub_suites: Vec<EvgTask>) -> MockBurnInService {
+        MockBurnInService {
+            sub_suites: sub_suites.clone(),
+        }
+    }
+
+    fn build_mocked_dependencies(burn_in_service: MockBurnInService) -> Dependencies {
+        Dependencies {
+            evg_config_utils: Arc::new(MockEvgConfigUtils {}),
+            gen_task_service: Arc::new(build_mock_generate_tasks_service()),
+            resmoke_config_actor: Arc::new(tokio::sync::Mutex::new(
+                MockResmokeConfigActorService {},
+            )),
+            burn_in_service: Arc::new(burn_in_service),
+        }
+    }
+
+    // tests for create_burn_in_worker.
+    #[tokio::test]
+    async fn test_create_burn_in_worker_should_add_task_when_burn_in_suites_are_present() {
+        let mock_burn_in_service = build_mocked_burn_in_service(vec![EvgTask {
+            ..Default::default()
+        }]);
+        let mock_deps = build_mocked_dependencies(mock_burn_in_service);
+        let task_map = Arc::new(HashMap::new());
+        let generated_tasks = Arc::new(Mutex::new(HashMap::new()));
+
+        let thread_handle = create_burn_in_worker(
+            &mock_deps,
+            task_map.clone(),
+            &BuildVariant {
+                ..Default::default()
+            },
+            "run_bv_name".to_string(),
+            generated_tasks.clone(),
+        );
+        thread_handle.await.unwrap();
+
+        assert_eq!(
+            generated_tasks
+                .lock()
+                .unwrap()
+                .contains_key(&format!("{}-{}", BURN_IN_PREFIX, "run_bv_name")),
+            true
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_burn_in_worker_should_not_add_task_when_burn_in_suites_are_absent() {
+        let mock_burn_in_service = build_mocked_burn_in_service(vec![]);
+        let mock_deps = build_mocked_dependencies(mock_burn_in_service);
+        let task_map = Arc::new(HashMap::new());
+        let generated_tasks = Arc::new(Mutex::new(HashMap::new()));
+
+        let thread_handle = create_burn_in_worker(
+            &mock_deps,
+            task_map.clone(),
+            &BuildVariant {
+                ..Default::default()
+            },
+            "run_bv_name".to_string(),
+            generated_tasks.clone(),
+        );
+        thread_handle.await.unwrap();
+
+        assert_eq!(
+            generated_tasks
+                .lock()
+                .unwrap()
+                .contains_key(&format!("{}-{}", BURN_IN_PREFIX, "run_bv_name")),
+            false
         );
     }
 }


### PR DESCRIPTION
The original burn_in_tags python script: https://github.com/mongodb/mongo/blob/f4de1bd3b7de8b3e93d7d051cbfe8544df71112f/buildscripts/burn_in_tags.py