### PR TITLE
DAG-1940 Generate tasks separately for Windows, MacOS, Linux distro groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 - 2022-08-01
+
+* Generate tasks separately for Windows, MacOS, Linux distro groups.
+
 ## 0.4.7 - 2022-07-14
 
 * Add support for burn_in_tags generation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.4.7"
+version = "0.5.0"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -111,3 +111,11 @@ pub const MULTIVERSION_LAST_CONTINUOUS: &str = "last_continuous";
 // Distros
 /// Name of compile task distro for burn_in_tags.
 pub const COMPILE_TASK_DISTRO: &str = "rhel80-xlarge";
+
+// Distro group names
+/// Windows distro group name.
+pub const WINDOWS: &str = "windows";
+/// MacOS distro group name.
+pub const MACOS: &str = "macos";
+/// Linux distro group name.
+pub const LINUX: &str = "linux";

--- a/src/services/config_extraction.rs
+++ b/src/services/config_extraction.rs
@@ -37,6 +37,8 @@ pub trait ConfigExtractionService: Sync + Send {
     /// # Arguments
     ///
     /// * `task-def` - Task definition of task to generate.
+    /// * `is_enterprise` - Is this being generated for an enterprise build variant.
+    /// * `platform` - Platform that task will run on.
     ///
     /// # Returns
     ///
@@ -45,6 +47,7 @@ pub trait ConfigExtractionService: Sync + Send {
         &self,
         task_def: &EvgTask,
         is_enterprise: bool,
+        platform: Option<String>,
     ) -> Result<ResmokeGenParams>;
 }
 
@@ -160,6 +163,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
             config_location: self.config_location.clone(),
             dependencies: self.determine_task_dependencies(task_def),
             is_enterprise,
+            platform: Some(evg_config_utils.infer_build_variant_platform(build_variant)),
         })
     }
 
@@ -169,6 +173,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
     ///
     /// * `task_def` - Task definition of task to generate.
     /// * `is_enterprise` - Is this being generated for an enterprise build variant.
+    /// * `platform` - Platform that task will run on.
     ///
     /// # Returns
     ///
@@ -177,6 +182,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
         &self,
         task_def: &EvgTask,
         is_enterprise: bool,
+        platform: Option<String>,
     ) -> Result<ResmokeGenParams> {
         let task_name = remove_gen_suffix(&task_def.name).to_string();
         let suite = self.evg_config_utils.find_suite_name(task_def).to_string();
@@ -209,6 +215,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
             dependencies: self.determine_task_dependencies(task_def),
             is_enterprise,
             pass_through_vars: self.evg_config_utils.get_gen_task_vars(task_def),
+            platform,
         })
     }
 }

--- a/src/task_types/burn_in_tests.rs
+++ b/src/task_types/burn_in_tests.rs
@@ -169,7 +169,7 @@ impl BurnInServiceImpl {
         for (index, test) in discovered_task.test_list.iter().enumerate() {
             let mut params = self
                 .config_extraction_service
-                .task_def_to_resmoke_params(task_def, false)?;
+                .task_def_to_resmoke_params(task_def, false, None)?;
             update_resmoke_params_for_burn_in(&mut params, test);
 
             if params.generate_multiversion_combos {
@@ -238,6 +238,7 @@ impl BurnInServiceImpl {
             origin_suite: origin_suite.clone(),
             mv_exclude_tags: suite_info.multiversion_tags.clone(),
             is_enterprise: false,
+            platform: None,
         };
 
         self.gen_resmoke_task_service.build_resmoke_sub_task(
@@ -513,6 +514,7 @@ mod tests {
             &self,
             _task_def: &EvgTask,
             _is_enterprise: bool,
+            _platform: Option<String>,
         ) -> Result<ResmokeGenParams> {
             Ok(ResmokeGenParams {
                 generate_multiversion_combos: self.is_multiversion,

--- a/src/task_types/fuzzer_tasks.rs
+++ b/src/task_types/fuzzer_tasks.rs
@@ -57,6 +57,8 @@ pub struct FuzzerGenTaskParams {
     pub dependencies: Vec<String>,
     /// Is this task for enterprise builds.
     pub is_enterprise: bool,
+    /// Name of platform the task will run on.
+    pub platform: Option<String>,
 }
 
 impl FuzzerGenTaskParams {
@@ -273,6 +275,7 @@ fn build_fuzzer_sub_task(
         Some(sub_task_index),
         params.num_tasks as usize,
         params.is_enterprise,
+        params.platform.as_deref(),
     );
 
     let mut commands = vec![];

--- a/src/task_types/resmoke_config_writer.rs
+++ b/src/task_types/resmoke_config_writer.rs
@@ -148,7 +148,13 @@ impl WriteConfigActorImpl {
 
                 let filename = format!(
                     "{}.yml",
-                    name_generated_task(&s.name, s.index, total_tasks, s.is_enterprise)
+                    name_generated_task(
+                        &s.name,
+                        s.index,
+                        total_tasks,
+                        s.is_enterprise,
+                        s.platform.as_deref()
+                    )
                 );
                 let mut path = PathBuf::from(&self.target_dir);
                 path.push(filename);
@@ -182,7 +188,13 @@ impl WriteConfigActorImpl {
                 let misc_config = origin_config.with_new_tests(None, Some(&test_list));
                 let filename = format!(
                     "{}.yml",
-                    name_generated_task(&s.name, s.index, total_tasks, s.is_enterprise)
+                    name_generated_task(
+                        &s.name,
+                        s.index,
+                        total_tasks,
+                        s.is_enterprise,
+                        s.platform.as_deref()
+                    )
                 );
                 let mut path = PathBuf::from(&self.target_dir);
                 path.push(filename);

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -68,6 +68,8 @@ pub struct ResmokeGenParams {
     pub is_enterprise: bool,
     /// Arguments to pass to 'run tests' function.
     pub pass_through_vars: Option<HashMap<String, ParamValue>>,
+    /// Name of platform the task will run on.
+    pub platform: Option<String>,
 }
 
 impl ResmokeGenParams {
@@ -200,6 +202,9 @@ pub struct SubSuite {
 
     /// Is sub-suite for a enterprise build_variant.
     pub is_enterprise: bool,
+
+    /// Platform of build_variant the sub-suite is for.
+    pub platform: Option<String>,
 }
 
 /// Information needed to generate resmoke configuration files for the generated task.
@@ -459,6 +464,7 @@ impl GenResmokeTaskServiceImpl {
                         exclude_test_list: None,
                         mv_exclude_tags: multiversion_tags.clone(),
                         is_enterprise: params.is_enterprise,
+                        platform: params.platform.clone(),
                     });
                     running_tests = vec![];
                     running_runtime = 0.0;
@@ -477,6 +483,7 @@ impl GenResmokeTaskServiceImpl {
                 exclude_test_list: None,
                 mv_exclude_tags: multiversion_tags,
                 is_enterprise: params.is_enterprise,
+                platform: params.platform.clone(),
             });
         }
 
@@ -558,6 +565,7 @@ impl GenResmokeTaskServiceImpl {
                     exclude_test_list: None,
                     mv_exclude_tags: multiversion_tags.clone(),
                     is_enterprise: params.is_enterprise,
+                    platform: params.platform.clone(),
                 });
                 current_tests = vec![];
                 i += 1;
@@ -573,6 +581,7 @@ impl GenResmokeTaskServiceImpl {
                 exclude_test_list: None,
                 mv_exclude_tags: multiversion_tags,
                 is_enterprise: params.is_enterprise,
+                platform: params.platform.clone(),
             });
         }
 
@@ -680,6 +689,7 @@ impl GenResmokeTaskServiceImpl {
             exclude_test_list: Some(full_test_list),
             mv_exclude_tags: multiversion_tags,
             is_enterprise: params.is_enterprise,
+            platform: params.platform.clone(),
         });
 
         Ok(sub_suites)
@@ -755,6 +765,7 @@ impl GenResmokeTaskService for GenResmokeTaskServiceImpl {
             sub_suite.index,
             total_sub_suites,
             params.is_enterprise,
+            params.platform.as_deref(),
         );
 
         let run_test_vars =

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,5 +28,5 @@ fn test_end2end_execution() {
     assert!(tmp_dir_path.exists());
 
     let files = std::fs::read_dir(tmp_dir_path).unwrap();
-    assert_eq!(1561, files.into_iter().collect::<Vec<_>>().len());
+    assert_eq!(2647, files.into_iter().collect::<Vec<_>>().len());
 }


### PR DESCRIPTION
After these changes a version generation for mongodb-mongo-master project has increased from ~337 sec to ~372 secs on my local machine:
```
{"timestamp":"2022-08-01T10:30:16.525079Z","level":"INFO","fields":{"message":"generation completed: 337 seconds"},"target":"mongo_task_generator"}
```

```
{"timestamp":"2022-08-01T10:39:08.927945Z","level":"INFO","fields":{"message":"generation completed: 372 seconds"},"target":"mongo_task_generator"}
```

Currently in evergreen it generates the version in ~143 seconds:
https://evergreen.mongodb.com/task_log_raw/mongodb_mongo_master_generate_tasks_for_version_version_gen_99286ff7b1f837df8449ef990b881c3ed1e3a64b_22_08_01_04_38_52/0?type=T#L915
```
{"timestamp":"2022-08-01T04:45:40.350646Z","level":"INFO","fields":{"message":"generation completed: 143 seconds"},"target":"mongo_task_generator"}
```