### PR TITLE
DAG-1967 Improve task splitting based on historic tests runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .emm-local.yml
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 0.5.2 - 2022-08-17
+* Improve task splitting based on historic tests runtime.
+
 ## 0.5.1 - 2022-08-12
 * Fix parsing the suite name from evergreen.yml for burn_in_* tasks.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.5.1"
+version = "0.5.2"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"


### PR DESCRIPTION
New task splitting solution does the following steps:
1. Sort tests by the runtime descending. Tests without historic runtime data are placed at the end of the list.
2. Iterate through the sorted list of tests and put each test into the subsuite with the least total runtime of tests that are already in the subsuite on the current iteration.

Evergreen patch: https://spruce.mongodb.com/version/62fce37f1e2d1770cae85cca
Evergreen patch nightly: https://spruce.mongodb.com/version/62fce3e1a4cf471e9da1ff43

Version gen runtime on nightly project is almost the same:
- waterfall: https://evergreen.mongodb.com/task_log_raw/mongodb_mongo_master_nightly_generate_tasks_for_version_version_gen_fa516c72b33889815888a15b787feec5fccf3138_22_08_15_00_08_23/0?type=T#L1242
- patch: https://evergreen.mongodb.com/task_log_raw/mongodb_mongo_master_nightly_generate_tasks_for_version_version_gen_patch_e7ec85efe78433e28875631d0c84b6b537c539cf_62fce3e1a4cf471e9da1ff43_22_08_17_12_50_12/0?type=T#L1590

Subsuites durations seems much more even:
- waterfall: https://spruce.mongodb.com/version/mongodb_mongo_master_nightly_fa516c72b33889815888a15b787feec5fccf3138/task-duration?duration=DESC&page=0&taskName=aggregation_secondary_reads%7Cversion_gen
- patch: https://spruce.mongodb.com/version/62fce3e1a4cf471e9da1ff43/task-duration?duration=DESC&page=0&taskName=aggregation_secondary_reads%7Cversion_gen