### PR TITLE
DAG-1986 Distribute tests without historic runtime data evenly between subsuites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.3 - 2022-08-19
+* Distribute tests without historic runtime data evenly between subsuites.
+
 ## 0.5.2 - 2022-08-17
 * Improve task splitting based on historic tests runtime.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.5.2"
+version = "0.5.3"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"


### PR DESCRIPTION
Follow-up change after [DAG-1967](https://jira.mongodb.org/browse/DAG-1967).
Evergreen patch: https://spruce.mongodb.com/version/62ff60ea2fbabe6d0b390036/task-duration?duration=DESC
Evergreen patch nightly: https://spruce.mongodb.com/version/62ff60f1e3c33116292f43ea/task-duration?duration=DESC