### PR TITLE
DAG-1992 Generate only burn_in tasks when --burn-in is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.0 - 2022-08-26
+* Generate only burn_in tasks when --burn-in is passed.
+
 ## 0.5.3 - 2022-08-19
 * Distribute tests without historic runtime data evenly between subsuites.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.5.3"
+version = "0.6.0"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/docs/generating_tasks.md
+++ b/docs/generating_tasks.md
@@ -160,11 +160,11 @@ the `"no_version_combinations"` tag should also be included.
 ### Burn in tests and burn in tags
 
 Newly added or modified tests might become flaky. In order to avoid that, those tests can be run
-continuously multiple times in a row to see, if the results are consistent. This process is called
+continuously multiple times in a row to see if the results are consistent. This process is called
 burn-in.
 
 `burn_in_tests_gen` task is used to generate burn-in tasks on the same buildvariant the task is
-added to. [Example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L3252-L3256)
+added to. The [example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L3252-L3256)
 of task configuration:
 
 ```yaml
@@ -175,11 +175,11 @@ of task configuration:
   - func: "generate resmoke tasks"
 ```
 
-`burn_in_tags_gen` task is used to generate separate burn-in buildvariants. This way we can add the
-task to the required buildvariant, that will generate another required buildvariants on the fly
-based on another non-required buildvariants with only necessary burn-in tasks.
+`burn_in_tags_gen` task is used to generate separate burn-in buildvariants. This way we can burn-in
+on the requested buildvariant as well as the other, additional buildvariants to ensure there is no
+difference between buildvariants.
 
-[Example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L4317-L4321)
+The [example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L4317-L4321)
 of task configuration:
 
 ```yaml
@@ -191,7 +191,7 @@ of task configuration:
 ```
 
 `burn_in_tag_buildvariants` buildvariant expansion is used to configure base buildvariant names.
-Base buildvariant names should be delimited by spaced. [Example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen.yml#L1257)
+Base buildvariant names should be delimited by spaces. The [example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen.yml#L1257)
 of `burn_in_tag_buildvariants` buildvariant expansion:
 
 ```yaml

--- a/docs/generating_tasks.md
+++ b/docs/generating_tasks.md
@@ -157,6 +157,49 @@ of the task definition. When this tag is present, both the extra setup steps and
 of multiversion sub-tasks will be preformed. In order to only perform the extra setup steps
 the `"no_version_combinations"` tag should also be included.
 
+### Burn in tests and burn in tags
+
+Newly added or modified tests might become flaky. In order to avoid that, those tests can be run
+continuously multiple times in a row to see, if the results are consistent. This process is called
+burn-in.
+
+`burn_in_tests_gen` task is used to generate burn-in tasks on the same buildvariant the task is
+added to. [Example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L3252-L3256)
+of task configuration:
+
+```yaml
+- <<: *gen_task_template
+  name: burn_in_tests_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+```
+
+`burn_in_tags_gen` task is used to generate separate burn-in buildvariants. This way we can add the
+task to the required buildvariant, that will generate another required buildvariants on the fly
+based on another non-required buildvariants with only necessary burn-in tasks.
+
+[Example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L4317-L4321)
+of task configuration:
+
+```yaml
+- <<: *gen_task_template
+  name: burn_in_tags_gen
+  tags: []
+  commands:
+  - func: "generate resmoke tasks"
+```
+
+`burn_in_tag_buildvariants` buildvariant expansion is used to configure base buildvariant names.
+Base buildvariant names should be delimited by spaced. [Example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen.yml#L1257)
+of `burn_in_tag_buildvariants` buildvariant expansion:
+
+```yaml
+burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem enterprise-rhel-80-64-bit-multiversion
+```
+
+Burn-in related tasks are generated when `--burn-in` is passed.
+
 ## Working with generated tasks
 
 A generated tasks is typically composed of a number of related sub-tasks. Because evergreen does
@@ -221,6 +264,11 @@ if the default value does not apply.
   store your resmokeconfig is a different directory, you can adjust this value:
   `python buildscripts/resmoke.py --configDir=path/to/resmokeconfig`.
 * **target-directory**: Directory to write generated configuration to. This defaults to `generated_resmoke_config`.
+* **burn-in**: Whether to generate burn_in related tasks. If specified only burn_in tasks will be
+  generated.
+* **burn-in-tests-command**: How to invoke the burn_in_tests command. The burn_in_tests command is
+  used to discover modified or added tests and the tasks they being run on. It defaults to
+  `python buildscripts/burn_in_tests.py`.
 
 ## Usage help
 
@@ -232,6 +280,10 @@ USAGE:
     mongo-task-generator [OPTIONS] --expansion-file <EXPANSION_FILE>
 
 OPTIONS:
+        --burn-in
+            Generate burn_in related tasks
+        --burn-in-tests-command <BURN_IN_TESTS_COMMAND>
+            Command to invoke burn_in_tests [default: "python buildscripts/burn_in_tests.py"]
         --evg-auth-file <EVG_AUTH_FILE>
             File with information on how to authenticate against the evergreen API [default:
             ~/.evergreen.yml]
@@ -240,7 +292,7 @@ OPTIONS:
         --expansion-file <EXPANSION_FILE>
             File containing expansions that impact task generation
         --generate-sub-tasks-config <GENERATE_SUB_TASKS_CONFIG>
-            File containing configuration for generating sub-tasks            
+            File containing configuration for generating sub-tasks
     -h, --help
             Print help information
         --resmoke-command <RESMOKE_COMMAND>

--- a/docs/generating_tasks.md
+++ b/docs/generating_tasks.md
@@ -177,7 +177,7 @@ of task configuration:
 
 `burn_in_tags_gen` task is used to generate separate burn-in buildvariants. This way we can burn-in
 on the requested buildvariant as well as the other, additional buildvariants to ensure there is no
-difference between buildvariants.
+difference between them.
 
 The [example](https://github.com/mongodb/mongo/blob/81c41bdfdc56f05973fae70e80e80919f18f50c9/etc/evergreen_yml_components/definitions.yml#L4317-L4321)
 of task configuration:

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::fmt::format;
 const DEFAULT_EVG_AUTH_FILE: &str = "~/.evergreen.yml";
 const DEFAULT_EVG_PROJECT_FILE: &str = "etc/evergreen.yml";
 const DEFAULT_RESMOKE_COMMAND: &str = "python buildscripts/resmoke.py";
+const DEFAULT_BURN_IN_TESTS_COMMAND: &str = "python buildscripts/burn_in_tests.py";
 const DEFAULT_TARGET_DIRECTORY: &str = "generated_resmoke_config";
 
 /// Expansions from evergreen to determine settings for how task should be generated.
@@ -84,6 +85,10 @@ struct Args {
     /// Generate burn_in related tasks.
     #[clap(long)]
     burn_in: bool,
+
+    /// Command to invoke burn_in_tests.
+    #[clap(long, default_value = DEFAULT_BURN_IN_TESTS_COMMAND)]
+    burn_in_tests_command: String,
 }
 
 /// Configure logging for the command execution.
@@ -116,6 +121,7 @@ async fn main() {
         generating_task: &evg_expansions.task_name,
         config_location: &evg_expansions.config_location(),
         gen_burn_in: args.burn_in,
+        burn_in_tests_command: &args.burn_in_tests_command,
     };
     let deps = Dependencies::new(execution_config).unwrap();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -61,5 +61,7 @@ fn test_end2end_burn_in_execution() {
     assert!(tmp_dir_path.exists());
 
     let files = std::fs::read_dir(tmp_dir_path).unwrap();
+    // Only one file `evergreen_config.json` should be generated.
+    // That means non-burn-in tasks are NOT generated.
     assert_eq!(1, files.into_iter().collect::<Vec<_>>().len());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,3 +30,36 @@ fn test_end2end_execution() {
     let files = std::fs::read_dir(tmp_dir_path).unwrap();
     assert_eq!(2647, files.into_iter().collect::<Vec<_>>().len());
 }
+
+#[test]
+fn test_end2end_burn_in_execution() {
+    let mut cmd = Command::cargo_bin("mongo-task-generator").unwrap();
+    let tmp_dir = TempDir::new("generated_resmoke_config").unwrap();
+
+    cmd.args(&[
+        "--target-directory",
+        tmp_dir.path().to_str().unwrap(),
+        "--expansion-file",
+        "tests/data/sample_expansions.yml",
+        "--evg-project-file",
+        "tests/data/evergreen.yml",
+        "--evg-auth-file",
+        "tests/data/sample_evergreen_auth.yml",
+        "--resmoke-command",
+        "python3 tests/mocks/resmoke.py",
+        "--use-task-split-fallback",
+        "--generate-sub-tasks-config",
+        "tests/data/sample_generate_subtasks_config.yml",
+        "--burn-in",
+        "--burn-in-tests-command",
+        "python3 tests/mocks/burn_in_tests.py",
+    ])
+    .assert()
+    .success();
+
+    let tmp_dir_path = tmp_dir.path();
+    assert!(tmp_dir_path.exists());
+
+    let files = std::fs::read_dir(tmp_dir_path).unwrap();
+    assert_eq!(1, files.into_iter().collect::<Vec<_>>().len());
+}

--- a/tests/mocks/burn_in_tests.py
+++ b/tests/mocks/burn_in_tests.py
@@ -1,0 +1,22 @@
+"""Mock of burn_in_tests.py for testing task generation."""
+def burn_in_discovery():
+    print("""
+discovered_tasks:
+- task_name: jsCore
+  test_list:
+  - tests/data/tests/test_0.js
+- task_name: sharding_jscore_passthrough
+  test_list:
+  - tests/data/tests/test_0.js
+- task_name: replica_sets_jscore_passthrough
+  test_list:
+  - tests/data/tests/test_0.js
+    """)
+
+
+def main():
+    burn_in_discovery()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When `--burn-in` is passed, only burn_in tasks are generated. Otherwise all the other tasks are generated.