### PR TITLE
DAG-1950: Make burn_in_tags compile task group and distro name configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+
+## 0.6.1 - 2022-09-06
+* Add the ability to get `distro_name` and `task_group_name` for `burn_in` tasks.
 ## 0.6.0 - 2022-08-26
 * Generate only burn_in tasks when --burn-in is passed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-
 ## 0.6.1 - 2022-09-06
 * Add the ability to get `distro_name` and `task_group_name` for `burn_in` tasks.
+
 ## 0.6.0 - 2022-08-26
 * Generate only burn_in tasks when --burn-in is passed.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/docs/generating_tasks.md
+++ b/docs/generating_tasks.md
@@ -196,6 +196,8 @@ of `burn_in_tag_buildvariants` buildvariant expansion:
 
 ```yaml
 burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem enterprise-rhel-80-64-bit-multiversion
+burn_in_tag_compile_distro: rhel80-large
+burn_in_tag_compile_task_group_name: compile_and_archive_dist_test_TG
 ```
 
 Burn-in related tasks are generated when `--burn-in` is passed.

--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -39,8 +39,6 @@ pub const GENERATOR_TASKS: &str = "generator_tasks";
 pub const BURN_IN_TESTS: &str = "burn_in_tests_gen";
 /// Name of burn_in_tags task.
 pub const BURN_IN_TAGS: &str = "burn_in_tags_gen";
-/// Name of compile task group.
-pub const COMPILE_TASK_GROUP_NAME: &str = "compile_and_archive_dist_test_TG";
 
 // Vars
 /// Variable that indicates a task is a fuzzer.
@@ -90,6 +88,10 @@ pub const MULTIVERSION_EXCLUDE_TAGS: &str = "multiversion_exclude_tags_version";
 pub const LARGE_DISTRO_EXPANSION: &str = "large_distro_name";
 /// List of build variant names delimited by spaces to generate burn_in_tags for.
 pub const BURN_IN_TAG_BUILD_VARIANTS: &str = "burn_in_tag_buildvariants";
+/// The distro to use when compiling burn_in_tags.
+pub const BURN_IN_TAG_COMPILE_DISTRO: &str = "burn_in_tag_compile_distro";
+/// The name to give the task group for compiling.
+pub const BURN_IN_TAG_COMPILE_TASK_GROUP_NAME: &str = "burn_in_tag_compile_task_group_name";
 /// Name of build variant to determine the timeouts for.
 pub const BURN_IN_BYPASS: &str = "burn_in_bypass";
 
@@ -110,10 +112,6 @@ pub const MULTIVERSION_EXCLUDE_TAGS_FILE: &str = "multiversion_exclude_tags.yml"
 pub const MULTIVERSION_LAST_LTS: &str = "last_lts";
 /// Name of last continuous configuration.
 pub const MULTIVERSION_LAST_CONTINUOUS: &str = "last_continuous";
-
-// Distros
-/// Name of compile task distro for burn_in_tags.
-pub const COMPILE_TASK_DISTRO: &str = "rhel80-xlarge";
 
 // Distro group names
 /// Windows distro group name.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,24 @@ trait GenerateTasksService: Sync + Send {
         generated_tasks: Arc<Mutex<GenTaskCollection>>,
     ) -> Result<Vec<BuildVariant>>;
 
+    /// Generate the burn_in build variant information for a build variant.
+    ///
+    /// # Arguments
+    ///
+    /// * `burn_in_tag_build_variant_info` - A map of burn_in build variants to config information about them.
+    /// * `build_variant` - The original build variant to generate burn_in information from.
+    /// * `build_variant_map` - A map of build variant names to their definitions.
+    ///
+    /// # Returns
+    ///
+    /// Nothing, modifies the burn_in_tag_build_variant_info with new values.
+    fn generate_burn_in_build_variant_info(
+        &self,
+        burn_in_tag_build_variant_info: &mut HashMap<String, BurnInTagBuildVariantInfo>,
+        build_variant: &BuildVariant,
+        build_variant_map: &HashMap<String, &BuildVariant>,
+    );
+
     /// Generate a task for the given task definition.
     ///
     /// # Arguments
@@ -595,6 +613,83 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
         Ok(generated_task)
     }
 
+    /// Generate the burn_in build variant information for a build variant.
+    ///
+    /// # Arguments
+    ///
+    /// * `burn_in_tag_build_variant_info` - A map of burn_in build variants to config information about them.
+    /// * `build_variant` - The original build variant to generate burn_in information from.
+    /// * `build_variant_map` - A map of build variant names to their definitions.
+    ///
+    /// # Returns
+    ///
+    /// Nothing, modifies the burn_in_tag_build_variant_info with new values.
+    fn generate_burn_in_build_variant_info(
+        &self,
+        burn_in_tag_build_variant_info: &mut HashMap<String, BurnInTagBuildVariantInfo>,
+        build_variant: &BuildVariant,
+        build_variant_map: &HashMap<String, &BuildVariant>,
+    ) {
+        let burn_in_tag_build_variants = self
+            .evg_config_utils
+            .lookup_and_split_by_whitespace_build_variant_expansion(
+                BURN_IN_TAG_BUILD_VARIANTS,
+                build_variant,
+            );
+        if burn_in_tag_build_variants.is_empty() {
+            panic!(
+            "`{}` build variant is either missing or has an empty list for the `{}` expansion. Set the expansion in your project's config to run {}.",
+            build_variant.name, BURN_IN_TAG_BUILD_VARIANTS, BURN_IN_TAGS
+        )
+        }
+        let compile_distro = self
+        .evg_config_utils
+        .lookup_build_variant_expansion(
+            BURN_IN_TAG_COMPILE_DISTRO,
+            build_variant,
+        ).unwrap_or_else(|| {
+            panic!(
+                "`{}` build variant is missing the `{}` expansion to run `{}`. Set the expansion in your project's config to continue.",
+                build_variant.name, BURN_IN_TAG_COMPILE_DISTRO, BURN_IN_TAGS
+            )
+        });
+        let compile_task_group_name = self
+        .evg_config_utils
+        .lookup_build_variant_expansion(
+            BURN_IN_TAG_COMPILE_TASK_GROUP_NAME,
+            build_variant,
+        ).unwrap_or_else(|| {
+            panic!(
+                "`{}` build variant is missing the `{}` expansion to run `{}`. Set the expansion in your project's config to continue.",
+                build_variant.name, BURN_IN_TAG_COMPILE_TASK_GROUP_NAME, BURN_IN_TAGS
+            )
+        });
+        for variant in burn_in_tag_build_variants {
+            if !build_variant_map.contains_key(&variant) {
+                panic!("`{}` is trying to create a build variant that does not exist: {}. Check the {} expansion in this variant.",
+                build_variant.name, variant, BURN_IN_TAG_BUILD_VARIANTS)
+            }
+            let bv_info = burn_in_tag_build_variant_info
+                .entry(variant.clone())
+                .or_insert(BurnInTagBuildVariantInfo {
+                    compile_distro: compile_distro.clone(),
+                    compile_task_group_name: compile_task_group_name.clone(),
+                });
+            if bv_info.compile_distro != compile_distro.clone() {
+                panic!(
+                    "`{}` is trying to set a different compile distro than already exists for `{}`. Check the `{}` expansions in your config.",
+                build_variant.name, variant, BURN_IN_TAG_COMPILE_DISTRO
+            )
+            }
+            if bv_info.compile_task_group_name != compile_task_group_name {
+                panic!(
+                    "`{}` is trying to set a different compile task group name than already exists for `{}`. Check the `{}` expansions in your config.",
+                build_variant.name, variant, BURN_IN_TAG_COMPILE_TASK_GROUP_NAME
+            )
+            }
+        }
+    }
+
     /// Create build variants definitions containing all the generated tasks for each build variant.
     ///
     /// # Arguments
@@ -630,54 +725,11 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
             for task in &build_variant.tasks {
                 if task.name == BURN_IN_TAGS {
                     if self.gen_burn_in {
-                        let burn_in_tag_build_variants = self
-                            .evg_config_utils
-                            .lookup_and_split_by_whitespace_build_variant_expansion(
-                                BURN_IN_TAG_BUILD_VARIANTS,
-                                build_variant,
-                            );
-                        let compile_distro = self
-                            .evg_config_utils
-                            .lookup_build_variant_expansion(
-                                BURN_IN_TAG_COMPILE_DISTRO,
-                                build_variant,
-                            ).unwrap_or_else(|| {
-                                panic!(
-                                    "`{}` is missing the burn_in_tag compile distro expansion. Set the '{}' expansion in your project's config to continue.",
-                                    build_variant.name, BURN_IN_TAG_COMPILE_DISTRO
-                                )
-                            });
-                        let compile_task_group_name = self
-                            .evg_config_utils
-                            .lookup_build_variant_expansion(
-                                BURN_IN_TAG_COMPILE_TASK_GROUP_NAME,
-                                build_variant,
-                            ).unwrap_or_else(|| {
-                                panic!(
-                                    "`{}` is missing the burn_in_tag compile task group name expansion. Set the '{}' expansion in your project's config to continue.",
-                                    build_variant.name, BURN_IN_TAG_COMPILE_TASK_GROUP_NAME
-                                )
-                            });
-                        for variant in burn_in_tag_build_variants {
-                            let bv_info = burn_in_tag_build_variant_info
-                                .entry(variant.clone())
-                                .or_insert(BurnInTagBuildVariantInfo {
-                                    compile_distro: compile_distro.clone(),
-                                    compile_task_group_name: compile_task_group_name.clone(),
-                                });
-                            if bv_info.compile_distro != compile_distro.clone() {
-                                panic!(
-                                    "`{}` is trying to set a different compile distro than already exists for {}. Check the {} expansions in your config.",
-                                    build_variant.name, variant, BURN_IN_TAG_COMPILE_DISTRO
-                                )
-                            }
-                            if bv_info.compile_task_group_name != compile_task_group_name {
-                                panic!(
-                                    "`{}` is trying to set a different compile task group name than already exists for {}. Check the {} expansions in your config.",
-                                    build_variant.name, variant, BURN_IN_TAG_COMPILE_TASK_GROUP_NAME
-                                )
-                            }
-                        }
+                        self.generate_burn_in_build_variant_info(
+                            &mut burn_in_tag_build_variant_info,
+                            build_variant,
+                            &build_variant_map,
+                        )
                     }
                     continue;
                 }

--- a/tests/data/burn_in/evergreen_with_empty_burn_in_variants.yml
+++ b/tests/data/burn_in/evergreen_with_empty_burn_in_variants.yml
@@ -1,0 +1,166 @@
+functions:
+  "f_expansions_write": &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
+
+variables:
+- &compile_task_group_template
+  name: compile_task_group_template
+  max_hosts: 1
+  tasks: []
+  setup_task:
+  - func: "f_expansions_write"
+  - func: "apply compile expansions"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  teardown_task:
+  - func: "f_expansions_write"
+  - func: "attach scons logs"
+  - func: "attach report"
+  - func: "attach artifacts"
+  - func: "kill processes"
+  - func: "save code coverage data"
+  - func: "save mongo coredumps"
+  - func: "save failed unittests"
+  - func: "save UndoDB recordings"
+  - func: "save unstripped dbtest"
+  - func: "save hang analyzer debugger files"
+  - func: "save disk statistics"
+  - func: "save system resource information"
+  - func: "save libfuzzertest corpora"
+  - func: "remove files"
+    vars:
+      files: >-
+        src/resmoke_error_code
+        src/build/scons/config.log
+        src/*.gcda.gcov
+        src/gcov-intermediate-files.tgz
+        src/*.core src/*.mdmp
+        mongo-coredumps.tgz
+        src/dist-unittests/bin/*
+        src/dist-unittests/lib/*
+        mongo-unittests.tgz
+        src/debugger*.*
+        src/mongo-hanganalyzer.tgz
+        diskstats.tgz
+        system-resource-info.tgz
+        ${report_file|src/report.json}
+        ${archive_file|src/archive.json}
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  - func: "kill processes"
+  - func: "cleanup environment"
+  # The python virtual environment is installed in ${workdir}, which is created in
+  # "set up venv".
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "get all modified patch files"
+  - func: "f_expansions_write"
+  - func: "configure evergreen api credentials"
+  - func: "get buildnumber"
+  - func: "f_expansions_write"
+  - func: "set up credentials"
+  - func: "use WiredTiger develop" # noop if ${use_wt_develop} is not "true"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"
+  - func: "f_expansions_write"
+  teardown_group:
+  - func: "f_expansions_write"
+  - func: "umount shared scons directory"
+  - func: "cleanup environment"
+  timeout:
+  - func: "f_expansions_write"
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
+
+task_groups:
+  - <<: *compile_task_group_template
+    name: compile_test_and_package_parallel_core_stream_TG
+    tasks:
+    - compile_dist_test
+
+tasks:
+
+- name: archive_dist_test
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: >-
+          archive-dist-test
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+## compile - build all scons targets except unittests ##
+- name: compile_dist_test
+  tags: []
+  depends_on: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: >-
+          install-dist-test
+          ${additional_compile_targets|}
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+- name: burn_in_tags_gen
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - func: "generate burn in tags"
+    vars:
+      max_revisions: 25
+      repeat_tests_secs: 600
+      repeat_tests_min: 2
+      repeat_tests_max: 1000
+
+buildvariants:
+  - &enterprise-rhel-80-64-bit-dynamic-required-template
+    name: enterprise-rhel-80-64-bit-dynamic-required
+    display_name: "! Shared Library Enterprise RHEL 8.0"
+    cron: "0 */4 * * *" # Every 4 hours starting at midnight
+    modules:
+    - enterprise
+    run_on:
+    - rhel80-small
+    expansions: &enterprise-rhel-80-64-bit-dynamic-required-expansions
+      additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+      compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+      csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+      multiversion_platform: rhel80
+      multiversion_edition: enterprise
+      has_packages: false
+      scons_cache_scope: shared
+      scons_cache_mode: all
+      jstestfuzz_num_generated_files: 40
+      jstestfuzz_concurrent_num_files: 10
+      target_resmoke_time: 10
+      max_sub_suites: 5
+      idle_timeout_factor: 1.5
+      exec_timeout_factor: 1.5
+      large_distro_name: rhel80-medium
+      burn_in_tag_buildvariants: 
+      burn_in_tag_compile_distro: rhelx-80
+      burn_in_tag_compile_task_group_name: compile-name
+      num_scons_link_jobs_available: 0.99
+    tasks:
+    - name: burn_in_tags_gen
+    - name: compile_test_and_package_parallel_core_stream_TG
+      distros:
+        - rhel80-xlarge

--- a/tests/data/burn_in/evergreen_with_no_burn_in_distro.yml
+++ b/tests/data/burn_in/evergreen_with_no_burn_in_distro.yml
@@ -1,0 +1,166 @@
+functions:
+  "f_expansions_write": &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
+
+variables:
+- &compile_task_group_template
+  name: compile_task_group_template
+  max_hosts: 1
+  tasks: []
+  setup_task:
+  - func: "f_expansions_write"
+  - func: "apply compile expansions"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  teardown_task:
+  - func: "f_expansions_write"
+  - func: "attach scons logs"
+  - func: "attach report"
+  - func: "attach artifacts"
+  - func: "kill processes"
+  - func: "save code coverage data"
+  - func: "save mongo coredumps"
+  - func: "save failed unittests"
+  - func: "save UndoDB recordings"
+  - func: "save unstripped dbtest"
+  - func: "save hang analyzer debugger files"
+  - func: "save disk statistics"
+  - func: "save system resource information"
+  - func: "save libfuzzertest corpora"
+  - func: "remove files"
+    vars:
+      files: >-
+        src/resmoke_error_code
+        src/build/scons/config.log
+        src/*.gcda.gcov
+        src/gcov-intermediate-files.tgz
+        src/*.core src/*.mdmp
+        mongo-coredumps.tgz
+        src/dist-unittests/bin/*
+        src/dist-unittests/lib/*
+        mongo-unittests.tgz
+        src/debugger*.*
+        src/mongo-hanganalyzer.tgz
+        diskstats.tgz
+        system-resource-info.tgz
+        ${report_file|src/report.json}
+        ${archive_file|src/archive.json}
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  - func: "kill processes"
+  - func: "cleanup environment"
+  # The python virtual environment is installed in ${workdir}, which is created in
+  # "set up venv".
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "get all modified patch files"
+  - func: "f_expansions_write"
+  - func: "configure evergreen api credentials"
+  - func: "get buildnumber"
+  - func: "f_expansions_write"
+  - func: "set up credentials"
+  - func: "use WiredTiger develop" # noop if ${use_wt_develop} is not "true"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"
+  - func: "f_expansions_write"
+  teardown_group:
+  - func: "f_expansions_write"
+  - func: "umount shared scons directory"
+  - func: "cleanup environment"
+  timeout:
+  - func: "f_expansions_write"
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
+
+task_groups:
+  - <<: *compile_task_group_template
+    name: compile_test_and_package_parallel_core_stream_TG
+    tasks:
+    - compile_dist_test
+
+tasks:
+
+- name: archive_dist_test
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: >-
+          archive-dist-test
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+## compile - build all scons targets except unittests ##
+- name: compile_dist_test
+  tags: []
+  depends_on: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: >-
+          install-dist-test
+          ${additional_compile_targets|}
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+- name: burn_in_tags_gen
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - func: "generate burn in tags"
+    vars:
+      max_revisions: 25
+      repeat_tests_secs: 600
+      repeat_tests_min: 2
+      repeat_tests_max: 1000
+
+buildvariants:
+  - &enterprise-rhel-80-64-bit-dynamic-required-template
+    name: enterprise-rhel-80-64-bit-dynamic-required
+    display_name: "! Shared Library Enterprise RHEL 8.0"
+    cron: "0 */4 * * *" # Every 4 hours starting at midnight
+    modules:
+    - enterprise
+    run_on:
+    - rhel80-small
+    expansions: &enterprise-rhel-80-64-bit-dynamic-required-expansions
+      additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+      compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+      csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+      multiversion_platform: rhel80
+      multiversion_edition: enterprise
+      has_packages: false
+      scons_cache_scope: shared
+      scons_cache_mode: all
+      jstestfuzz_num_generated_files: 40
+      jstestfuzz_concurrent_num_files: 10
+      target_resmoke_time: 10
+      max_sub_suites: 5
+      idle_timeout_factor: 1.5
+      exec_timeout_factor: 1.5
+      large_distro_name: rhel80-medium
+      burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-dynamic-required
+      # burn_in_tag_compile_distro: rhelx-80
+      burn_in_tag_compile_task_group_name: compile-name
+      num_scons_link_jobs_available: 0.99
+    tasks:
+    - name: burn_in_tags_gen
+    - name: compile_test_and_package_parallel_core_stream_TG
+      distros:
+        - rhel80-xlarge

--- a/tests/data/burn_in/evergreen_with_no_burn_in_task_group.yml
+++ b/tests/data/burn_in/evergreen_with_no_burn_in_task_group.yml
@@ -1,0 +1,166 @@
+functions:
+  "f_expansions_write": &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
+
+variables:
+- &compile_task_group_template
+  name: compile_task_group_template
+  max_hosts: 1
+  tasks: []
+  setup_task:
+  - func: "f_expansions_write"
+  - func: "apply compile expansions"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  teardown_task:
+  - func: "f_expansions_write"
+  - func: "attach scons logs"
+  - func: "attach report"
+  - func: "attach artifacts"
+  - func: "kill processes"
+  - func: "save code coverage data"
+  - func: "save mongo coredumps"
+  - func: "save failed unittests"
+  - func: "save UndoDB recordings"
+  - func: "save unstripped dbtest"
+  - func: "save hang analyzer debugger files"
+  - func: "save disk statistics"
+  - func: "save system resource information"
+  - func: "save libfuzzertest corpora"
+  - func: "remove files"
+    vars:
+      files: >-
+        src/resmoke_error_code
+        src/build/scons/config.log
+        src/*.gcda.gcov
+        src/gcov-intermediate-files.tgz
+        src/*.core src/*.mdmp
+        mongo-coredumps.tgz
+        src/dist-unittests/bin/*
+        src/dist-unittests/lib/*
+        mongo-unittests.tgz
+        src/debugger*.*
+        src/mongo-hanganalyzer.tgz
+        diskstats.tgz
+        system-resource-info.tgz
+        ${report_file|src/report.json}
+        ${archive_file|src/archive.json}
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  - func: "kill processes"
+  - func: "cleanup environment"
+  # The python virtual environment is installed in ${workdir}, which is created in
+  # "set up venv".
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "get all modified patch files"
+  - func: "f_expansions_write"
+  - func: "configure evergreen api credentials"
+  - func: "get buildnumber"
+  - func: "f_expansions_write"
+  - func: "set up credentials"
+  - func: "use WiredTiger develop" # noop if ${use_wt_develop} is not "true"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"
+  - func: "f_expansions_write"
+  teardown_group:
+  - func: "f_expansions_write"
+  - func: "umount shared scons directory"
+  - func: "cleanup environment"
+  timeout:
+  - func: "f_expansions_write"
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
+
+task_groups:
+  - <<: *compile_task_group_template
+    name: compile_test_and_package_parallel_core_stream_TG
+    tasks:
+    - compile_dist_test
+
+tasks:
+
+- name: archive_dist_test
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: >-
+          archive-dist-test
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+## compile - build all scons targets except unittests ##
+- name: compile_dist_test
+  tags: []
+  depends_on: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: >-
+          install-dist-test
+          ${additional_compile_targets|}
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+- name: burn_in_tags_gen
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - func: "generate burn in tags"
+    vars:
+      max_revisions: 25
+      repeat_tests_secs: 600
+      repeat_tests_min: 2
+      repeat_tests_max: 1000
+
+buildvariants:
+  - &enterprise-rhel-80-64-bit-dynamic-required-template
+    name: enterprise-rhel-80-64-bit-dynamic-required
+    display_name: "! Shared Library Enterprise RHEL 8.0"
+    cron: "0 */4 * * *" # Every 4 hours starting at midnight
+    modules:
+    - enterprise
+    run_on:
+    - rhel80-small
+    expansions: &enterprise-rhel-80-64-bit-dynamic-required-expansions
+      additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+      compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+      csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+      multiversion_platform: rhel80
+      multiversion_edition: enterprise
+      has_packages: false
+      scons_cache_scope: shared
+      scons_cache_mode: all
+      jstestfuzz_num_generated_files: 40
+      jstestfuzz_concurrent_num_files: 10
+      target_resmoke_time: 10
+      max_sub_suites: 5
+      idle_timeout_factor: 1.5
+      exec_timeout_factor: 1.5
+      large_distro_name: rhel80-medium
+      burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-dynamic-required
+      burn_in_tag_compile_distro: rhelx-80
+      # burn_in_tag_compile_task_group_name: compile-name
+      num_scons_link_jobs_available: 0.99
+    tasks:
+    - name: burn_in_tags_gen
+    - name: compile_test_and_package_parallel_core_stream_TG
+      distros:
+        - rhel80-xlarge

--- a/tests/data/burn_in/evergreen_with_no_burn_in_variants.yml
+++ b/tests/data/burn_in/evergreen_with_no_burn_in_variants.yml
@@ -1,0 +1,166 @@
+functions:
+  "f_expansions_write": &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
+
+variables:
+- &compile_task_group_template
+  name: compile_task_group_template
+  max_hosts: 1
+  tasks: []
+  setup_task:
+  - func: "f_expansions_write"
+  - func: "apply compile expansions"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  teardown_task:
+  - func: "f_expansions_write"
+  - func: "attach scons logs"
+  - func: "attach report"
+  - func: "attach artifacts"
+  - func: "kill processes"
+  - func: "save code coverage data"
+  - func: "save mongo coredumps"
+  - func: "save failed unittests"
+  - func: "save UndoDB recordings"
+  - func: "save unstripped dbtest"
+  - func: "save hang analyzer debugger files"
+  - func: "save disk statistics"
+  - func: "save system resource information"
+  - func: "save libfuzzertest corpora"
+  - func: "remove files"
+    vars:
+      files: >-
+        src/resmoke_error_code
+        src/build/scons/config.log
+        src/*.gcda.gcov
+        src/gcov-intermediate-files.tgz
+        src/*.core src/*.mdmp
+        mongo-coredumps.tgz
+        src/dist-unittests/bin/*
+        src/dist-unittests/lib/*
+        mongo-unittests.tgz
+        src/debugger*.*
+        src/mongo-hanganalyzer.tgz
+        diskstats.tgz
+        system-resource-info.tgz
+        ${report_file|src/report.json}
+        ${archive_file|src/archive.json}
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set task expansion macros"
+  - func: "f_expansions_write"
+  - func: "kill processes"
+  - func: "cleanup environment"
+  # The python virtual environment is installed in ${workdir}, which is created in
+  # "set up venv".
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "get all modified patch files"
+  - func: "f_expansions_write"
+  - func: "configure evergreen api credentials"
+  - func: "get buildnumber"
+  - func: "f_expansions_write"
+  - func: "set up credentials"
+  - func: "use WiredTiger develop" # noop if ${use_wt_develop} is not "true"
+  - func: "set up win mount script"
+  - func: "generate compile expansions"
+  - func: "f_expansions_write"
+  teardown_group:
+  - func: "f_expansions_write"
+  - func: "umount shared scons directory"
+  - func: "cleanup environment"
+  timeout:
+  - func: "f_expansions_write"
+  - func: "run hang analyzer"
+  - func: "wait for resmoke to shutdown"
+
+task_groups:
+  - <<: *compile_task_group_template
+    name: compile_test_and_package_parallel_core_stream_TG
+    tasks:
+    - compile_dist_test
+
+tasks:
+
+- name: archive_dist_test
+  tags: []
+  depends_on:
+    - name: compile_dist_test
+  commands:
+    - *f_expansions_write
+    - func: "scons compile"
+      vars:
+        targets: >-
+          archive-dist-test
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+## compile - build all scons targets except unittests ##
+- name: compile_dist_test
+  tags: []
+  depends_on: []
+  commands:
+    - func: "scons compile"
+      vars:
+        targets: >-
+          install-dist-test
+          ${additional_compile_targets|}
+        task_compile_flags: >-
+          PREFIX=dist-test
+
+- name: burn_in_tags_gen
+  tags: []
+  depends_on:
+    - name: archive_dist_test
+  commands:
+  - command: manifest.load
+  - func: "git get project and add git tag"
+  - func: "set up venv"
+  - func: "upload pip requirements"
+  - func: "configure evergreen api credentials"
+  - func: "generate burn in tags"
+    vars:
+      max_revisions: 25
+      repeat_tests_secs: 600
+      repeat_tests_min: 2
+      repeat_tests_max: 1000
+
+buildvariants:
+  - &enterprise-rhel-80-64-bit-dynamic-required-template
+    name: enterprise-rhel-80-64-bit-dynamic-required
+    display_name: "! Shared Library Enterprise RHEL 8.0"
+    cron: "0 */4 * * *" # Every 4 hours starting at midnight
+    modules:
+    - enterprise
+    run_on:
+    - rhel80-small
+    expansions: &enterprise-rhel-80-64-bit-dynamic-required-expansions
+      additional_package_targets: archive-mongocryptd archive-mongocryptd-debug archive-mh archive-mh-debug
+      compile_flags: --ssl MONGO_DISTMOD=rhel80 -j$(grep -c ^processor /proc/cpuinfo) --variables-files=etc/scons/mongodbtoolchain_v3_gcc.vars --link-model=dynamic
+      csfle_task_compile_flags: SHLINKFLAGS_EXTRA="-Wl,-Bsymbolic -Wl,--no-gnu-unique" CCFLAGS="-fno-gnu-unique"
+      multiversion_platform: rhel80
+      multiversion_edition: enterprise
+      has_packages: false
+      scons_cache_scope: shared
+      scons_cache_mode: all
+      jstestfuzz_num_generated_files: 40
+      jstestfuzz_concurrent_num_files: 10
+      target_resmoke_time: 10
+      max_sub_suites: 5
+      idle_timeout_factor: 1.5
+      exec_timeout_factor: 1.5
+      large_distro_name: rhel80-medium
+      # burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-dynamic-required
+      burn_in_tag_compile_distro: rhelx-80
+      burn_in_tag_compile_task_group_name: compile-name
+      num_scons_link_jobs_available: 0.99
+    tasks:
+    - name: burn_in_tags_gen
+    - name: compile_test_and_package_parallel_core_stream_TG
+      distros:
+        - rhel80-xlarge

--- a/tests/data/evergreen.yml
+++ b/tests/data/evergreen.yml
@@ -8454,6 +8454,8 @@ buildvariants:
     max_sub_suites: 5
     large_distro_name: rhel80-medium
     burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem linux-64-duroff enterprise-rhel-80-64-bit-multiversion
+    burn_in_tag_compile_distro: rhelx-80
+    burn_in_tag_compile_task_group_name: compile-name
     num_scons_link_jobs_available: 0.99
     test_flags: >-
       --mongodSetParameters="{roundtripBsonColumnOnValidate: true}"
@@ -9884,6 +9886,8 @@ buildvariants:
     exec_timeout_factor: 1.5
     large_distro_name: rhel80-medium
     burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem linux-64-duroff enterprise-rhel-80-64-bit-multiversion
+    burn_in_tag_compile_distro: rhelx-80
+    burn_in_tag_compile_task_group_name: compile-name
     num_scons_link_jobs_available: 0.99
   tasks:
   - name: compile_test_and_package_parallel_core_stream_TG
@@ -10175,6 +10179,8 @@ buildvariants:
     max_sub_suites: 5
     large_distro_name: rhel80-medium
     burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem linux-64-duroff enterprise-rhel-80-64-bit-multiversion
+    burn_in_tag_compile_distro: rhelx-80
+    burn_in_tag_compile_task_group_name: compile-name
     num_scons_link_jobs_available: 0.99
     test_flags: >-
       --mongodSetParameters="{internalQueryForceClassicEngine: true}"


### PR DESCRIPTION
Patch:https://spruce.mongodb.com/version/630e63453066156e2ff2b9ee/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC