### PR TITLE
DAG-1935: Have better messages when doing resmoke calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.2 - 2022-09-14
+* Propogate up errors when calling resmoke.
+
 ## 0.6.1 - 2022-09-06
 * Add the ability to get `distro_name` and `task_group_name` for `burn_in` tasks.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.6.1"
+version = "0.6.2"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/resmoke/external_cmd.rs
+++ b/src/resmoke/external_cmd.rs
@@ -24,12 +24,14 @@ pub fn run_command(command: &[&str]) -> Result<String> {
 
     if !cmd.status.success() {
         let error_message = String::from_utf8_lossy(&cmd.stderr).to_string();
+        let regular_info = String::from_utf8_lossy(&cmd.stdout).to_string();
 
         event!(
             Level::ERROR,
             binary = binary,
             args = args.join(" "),
             error_message = error_message,
+            stdout = regular_info,
             "Command encountered an error",
         );
         bail!("Command encountered an error")


### PR DESCRIPTION
[Successful patch](https://spruce.mongodb.com/task/mongodb_mongo_master_generate_tasks_for_version_version_gen_patch_d8ce3ee2e020d1ab2fa611a2a0f0a222b06b9779_63222a26e3c33123f006c13a_22_09_14_19_23_34/logs?execution=0)
[Patch with resmoke error](https://evergreen.mongodb.com/filediff/631badee0305b92ba80bceb6/?file_name=evergreen%2Fbuild_variant_generate.sh&patch_number=0)
[Error log](https://evergreen.mongodb.com/lobster/evergreen/task/mongosync_rhel80_build_variant_gen_patch_ea007a3f028bccbc41f5d5a60df1d4e0dffc3503_631badee0305b92ba80bceb6_22_09_09_21_19_51/1/task#bookmarks=0%2C501&l=1&shareLine=479)