### PR TITLE
DAG-2208 uncomment workaround for EVG issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.5 - 2022-10-23
+* Remove workaround for EVG-18112 introduced in 0.6.4.
+
 ## 0.6.4 - 2022-10-14
 * Update burn_in_tags to depend on existing compile tasks.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo-task-generator"
-version = "0.6.4"
+version = "0.6.5"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -796,6 +796,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 generated_build_variants.push(
                     deps.burn_in_service.generate_burn_in_tags_build_variant(
                         base_build_variant,
+                        bv_info.compile_variant,
                         run_build_variant_name,
                         generated_task.as_ref(),
                         &variant_task_dependencies,
@@ -1265,6 +1266,7 @@ mod tests {
         fn generate_burn_in_tags_build_variant(
             &self,
             _base_build_variant: &BuildVariant,
+            _compile_build_variant_name: String,
             _run_build_variant_name: String,
             _generated_task: &dyn GeneratedSuite,
             _variant_task_dependencies: &[TaskDependency],

--- a/src/task_types/burn_in_tests.rs
+++ b/src/task_types/burn_in_tests.rs
@@ -14,6 +14,7 @@ use crate::{
     resmoke::burn_in_proxy::{BurnInDiscovery, DiscoveredTask},
     services::config_extraction::ConfigExtractionService,
     task_types::resmoke_tasks::{GeneratedResmokeSuite, SubSuite},
+    COMPILE_VARIANT,
 };
 
 use super::{
@@ -53,6 +54,7 @@ pub trait BurnInService: Sync + Send {
     /// # Arguments
     ///
     /// * `base_build_variant` - Build variant to generate burn_in_tags build variant based on.
+    /// * `compile_build_variant_name` - Build variant name to generate artifacts for burn_in_tests.
     /// * `run_build_variant_name` - Build variant name to run burn_in_tests task on.
     /// * `generated_task` - Generated burn_in_tests task.
     /// * `variant_task_dependencies` - List of dependencies for all tasks on this variant.
@@ -63,6 +65,7 @@ pub trait BurnInService: Sync + Send {
     fn generate_burn_in_tags_build_variant(
         &self,
         base_build_variant: &BuildVariant,
+        compile_build_variant_name: String,
         run_build_variant_name: String,
         generated_task: &dyn GeneratedSuite,
         variant_task_dependencies: &[TaskDependency],
@@ -324,6 +327,7 @@ impl BurnInService for BurnInServiceImpl {
     /// # Arguments
     ///
     /// * `base_build_variant` - Build variant to generate burn_in_tags build variant based on.
+    /// * `compile_build_variant_name` - Build variant name to generate artifacts for burn_in_tests.
     /// * `run_build_variant_name` - Build variant name to run burn_in_tests task on.
     /// * `generated_task` - Generated burn_in_tests task.
     /// * `compile_distro` - What distro to run compile on.
@@ -335,9 +339,10 @@ impl BurnInService for BurnInServiceImpl {
     fn generate_burn_in_tags_build_variant(
         &self,
         base_build_variant: &BuildVariant,
+        compile_build_variant_name: String,
         run_build_variant_name: String,
         generated_task: &dyn GeneratedSuite,
-        _variant_task_dependencies: &[TaskDependency],
+        variant_task_dependencies: &[TaskDependency],
     ) -> BuildVariant {
         let mut gen_config = BurnInTagsGeneratedConfig::new();
 
@@ -352,6 +357,9 @@ impl BurnInService for BurnInServiceImpl {
             BURN_IN_BYPASS.to_string(),
             base_build_variant.name.to_string(),
         );
+        gen_config
+            .expansions
+            .insert(COMPILE_VARIANT.to_string(), compile_build_variant_name);
 
         gen_config
             .gen_task_specs
@@ -360,17 +368,15 @@ impl BurnInService for BurnInServiceImpl {
             .display_tasks
             .push(generated_task.build_display_task());
 
-        // Commented out in favor of static variant definitions in evergreen.yml
-        // due to https://jira.mongodb.org/browse/EVG-18112
         BuildVariant {
             name: gen_config.build_variant_name.clone(),
             tasks: gen_config.gen_task_specs.clone(),
-            // display_name: gen_config.build_variant_display_name.clone(),
-            // run_on: base_build_variant.run_on.clone(),
+            display_name: gen_config.build_variant_display_name.clone(),
+            run_on: base_build_variant.run_on.clone(),
             display_tasks: Some(gen_config.display_tasks.clone()),
-            // modules: base_build_variant.modules.clone(),
-            // expansions: Some(gen_config.expansions.clone()),
-            // depends_on: Some(variant_task_dependencies.to_vec()),
+            modules: base_build_variant.modules.clone(),
+            expansions: Some(gen_config.expansions.clone()),
+            depends_on: Some(variant_task_dependencies.to_vec()),
             activate: Some(false),
             ..Default::default()
         }
@@ -645,6 +651,8 @@ mod tests {
             ..Default::default()
         };
         let run_build_variant_name = "run-build-variant-name".to_string();
+        let compile_build_variant_name = "compile-build-variant-name".to_string();
+
         let generated_task: &dyn GeneratedSuite = &GeneratedResmokeSuite {
             task_name: "display_task_name".to_string(),
             sub_suites: vec![EvgTask {
@@ -661,34 +669,37 @@ mod tests {
 
         let burn_in_tags_build_variant = burn_in_service.generate_burn_in_tags_build_variant(
             &base_build_variant,
+            compile_build_variant_name,
             run_build_variant_name,
             generated_task,
             &variant_task_dep,
         );
 
+        let expansions = burn_in_tags_build_variant.expansions.unwrap_or_default();
+
         assert_eq!(burn_in_tags_build_variant.name, "run-build-variant-name");
 
-        // Commented out in favor of static variant definitions in evergreen.yml
-        // due to https://jira.mongodb.org/browse/EVG-18112
-        // assert_eq!(
-        //     burn_in_tags_build_variant.display_name,
-        //     Some("! base build variant display name".to_string())
-        // );
-        // assert_eq!(
-        //     burn_in_tags_build_variant.run_on,
-        //     Some(vec!["base_distro_name".to_string()])
-        // );
-        // assert_eq!(
-        //     burn_in_tags_build_variant.modules,
-        //     Some(vec!["base_module_name".to_string()])
-        // );
-        // assert_eq!(
-        //     burn_in_tags_build_variant
-        //         .expansions
-        //         .unwrap_or_default()
-        //         .get(BURN_IN_BYPASS),
-        //     Some(&"base-build-variant-name".to_string())
-        // );
+        assert_eq!(
+            burn_in_tags_build_variant.display_name,
+            Some("! base build variant display name".to_string())
+        );
+        assert_eq!(
+            burn_in_tags_build_variant.run_on,
+            Some(vec!["base_distro_name".to_string()])
+        );
+        assert_eq!(
+            burn_in_tags_build_variant.modules,
+            Some(vec!["base_module_name".to_string()])
+        );
+        assert_eq!(
+            expansions.get(BURN_IN_BYPASS),
+            Some(&"base-build-variant-name".to_string())
+        );
+
+        assert_eq!(
+            expansions.get(COMPILE_VARIANT),
+            Some(&"compile-build-variant-name".to_string())
+        );
 
         assert_eq!(
             burn_in_tags_build_variant.display_tasks.unwrap_or_default()[0].name,


### PR DESCRIPTION
It turned out that only the `build_by_id()` EVG API was broken. `tasks_by_build()` worked well as an alternative so I'm uncommenting the temporary excluded code from #51.

One other change is to add the `compile_variant` expansion that I had missed in the original PR.

I'm going to skip the line and merge this given the code was a part of #51. Please feel free to revert/amend if anything doesn't look right.