### PR TITLE
DAG-2316 Apply appropriate large distros to tasks according to build variant configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.1 - 2022-01-12
+* Apply appropriate large distros to tasks according to build variant configuration.
+
 ## 0.7.0 - 2022-12-16
 * Add support for burn_in_tasks generation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.0"
+version = "0.7.1"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,6 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 task_def,
                 is_enterprise,
                 Some(platform),
-                build_variant,
             )?;
             Some(
                 self.gen_resmoke_service
@@ -700,13 +699,17 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 };
 
                 if let Some(generated_task) = generated_tasks.get(&task_name) {
+                    let large_distro = self
+                        .config_extraction_service
+                        .determine_distro(generated_task.as_ref(), build_variant)?;
+
                     generating_tasks.push(&task.name);
                     gen_config
                         .display_tasks
                         .push(generated_task.build_display_task());
                     gen_config
                         .gen_task_specs
-                        .extend(generated_task.build_task_ref());
+                        .extend(generated_task.build_task_ref(large_distro));
                 }
             }
 
@@ -755,7 +758,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                         run_build_variant_name,
                         generated_task.as_ref(),
                         &variant_task_dependencies,
-                    ),
+                    )?,
                 );
             }
         }
@@ -1144,8 +1147,15 @@ mod tests {
             _task_def: &EvgTask,
             _is_enterprise: bool,
             _platform: Option<String>,
-            _build_variant: &BuildVariant,
         ) -> Result<ResmokeGenParams> {
+            todo!()
+        }
+
+        fn determine_distro(
+            &self,
+            _generated_suite: &dyn GeneratedSuite,
+            _build_variant: &BuildVariant,
+        ) -> Result<Option<String>> {
             todo!()
         }
     }
@@ -1197,7 +1207,7 @@ mod tests {
             _run_build_variant_name: String,
             _generated_task: &dyn GeneratedSuite,
             _variant_task_dependencies: &[TaskDependency],
-        ) -> BuildVariant {
+        ) -> Result<BuildVariant> {
             todo!()
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,7 +701,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 if let Some(generated_task) = generated_tasks.get(&task_name) {
                     let large_distro = self
                         .config_extraction_service
-                        .determine_distro(generated_task.as_ref(), build_variant)?;
+                        .determine_large_distro(generated_task.as_ref(), build_variant)?;
 
                     generating_tasks.push(&task.name);
                     gen_config
@@ -1151,7 +1151,7 @@ mod tests {
             todo!()
         }
 
-        fn determine_distro(
+        fn determine_large_distro(
             &self,
             _generated_suite: &dyn GeneratedSuite,
             _build_variant: &BuildVariant,

--- a/src/services/config_extraction.rs
+++ b/src/services/config_extraction.rs
@@ -54,7 +54,7 @@ pub trait ConfigExtractionService: Sync + Send {
         platform: Option<String>,
     ) -> Result<ResmokeGenParams>;
 
-    /// Determine which distro the given sub-tasks should run on.
+    /// Determine large distro name if the given sub-tasks should run on it.
     ///
     /// By default, we won't specify a distro and they will just use the default for the build
     /// variant. If they specify `use_large_distro` then we should instead use the large distro
@@ -69,7 +69,7 @@ pub trait ConfigExtractionService: Sync + Send {
     /// # Returns
     ///
     /// Large distro name if needed.
-    fn determine_distro(
+    fn determine_large_distro(
         &self,
         generated_task: &dyn GeneratedSuite,
         build_variant: &BuildVariant,
@@ -248,7 +248,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
         })
     }
 
-    /// Determine which distro the given sub-tasks should run on.
+    /// Determine large distro name if the given sub-tasks should run on it.
     ///
     /// By default, we won't specify a distro and they will just use the default for the build
     /// variant. If they specify `use_large_distro` then we should instead use the large distro
@@ -263,7 +263,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
     /// # Returns
     ///
     /// Large distro name if needed.
-    fn determine_distro(
+    fn determine_large_distro(
         &self,
         generated_task: &dyn GeneratedSuite,
         build_variant: &BuildVariant,
@@ -362,14 +362,14 @@ mod tests {
         );
     }
 
-    // Tests for determine_distro.
+    // Tests for determine_large_distro.
     #[rstest]
     #[case(vec![false, false], None, None)]
     #[case(vec![false, false], Some("large_distro".to_string()), None)]
     #[case(vec![true, false], Some("large_distro".to_string()), Some("large_distro".to_string()))]
     #[case(vec![false, true], Some("large_distro".to_string()), Some("large_distro".to_string()))]
     #[case(vec![true, true], Some("large_distro".to_string()), Some("large_distro".to_string()))]
-    fn test_determine_distro_should_return_large_distro_name(
+    fn test_determine_large_distro_should_return_large_distro_name(
         #[case] use_large_distro: Vec<bool>,
         #[case] large_distro_name: Option<String>,
         #[case] expected_distro: Option<String>,
@@ -398,15 +398,15 @@ mod tests {
             });
         };
 
-        let distro = config_extraction_service
-            .determine_distro(generated_task, &build_variant)
+        let large_distro = config_extraction_service
+            .determine_large_distro(generated_task, &build_variant)
             .unwrap();
 
-        assert_eq!(distro, expected_distro);
+        assert_eq!(large_distro, expected_distro);
     }
 
     #[test]
-    fn test_determine_distro_should_fail_if_no_large_distro() {
+    fn test_determine_large_distro_should_fail_if_no_large_distro() {
         let config_extraction_service = build_mocked_config_extraction_service();
         let generated_task: &dyn GeneratedSuite = &GeneratedResmokeSuite {
             task_name: "display_task_name".to_string(),
@@ -422,13 +422,14 @@ mod tests {
             ..Default::default()
         };
 
-        let distro = config_extraction_service.determine_distro(generated_task, &build_variant);
+        let large_distro =
+            config_extraction_service.determine_large_distro(generated_task, &build_variant);
 
-        assert!(distro.is_err());
+        assert!(large_distro.is_err());
     }
 
     #[test]
-    fn test_determine_distro_respects_ignore_missing_large_distro() {
+    fn test_determine_large_distro_respects_ignore_missing_large_distro() {
         let mut config_extraction_service = build_mocked_config_extraction_service();
         config_extraction_service.gen_sub_tasks_config = Some(GenerateSubTasksConfig {
             build_variant_large_distro_exceptions: hashset! {
@@ -452,8 +453,9 @@ mod tests {
             ..Default::default()
         };
 
-        let distro = config_extraction_service.determine_distro(generated_task, &build_variant);
+        let large_distro =
+            config_extraction_service.determine_large_distro(generated_task, &build_variant);
 
-        assert!(distro.is_ok());
+        assert!(large_distro.is_ok());
     }
 }

--- a/src/task_types/burn_in_tests.rs
+++ b/src/task_types/burn_in_tests.rs
@@ -454,7 +454,7 @@ impl BurnInService for BurnInServiceImpl {
 
         let large_distro = self
             .config_extraction_service
-            .determine_distro(generated_task, base_build_variant)?;
+            .determine_large_distro(generated_task, base_build_variant)?;
 
         gen_config
             .gen_task_specs
@@ -669,7 +669,7 @@ mod tests {
             })
         }
 
-        fn determine_distro(
+        fn determine_large_distro(
             &self,
             _generated_task: &dyn GeneratedSuite,
             _build_variant: &BuildVariant,

--- a/src/task_types/fuzzer_tasks.rs
+++ b/src/task_types/fuzzer_tasks.rs
@@ -165,9 +165,9 @@ impl GeneratedSuite for FuzzerTask {
         self.sub_tasks
             .clone()
             .into_iter()
-            .map(|s| GeneratedSubTask {
-                evg_task: s,
-                ..Default::default()
+            .map(|sub_task| GeneratedSubTask {
+                evg_task: sub_task,
+                use_large_distro: false,
             })
             .collect()
     }
@@ -453,6 +453,27 @@ mod tests {
         };
 
         assert_eq!(fuzzer_task.sub_tasks().len(), 2);
+    }
+
+    #[test]
+    fn test_build_task_ref() {
+        let fuzzer_task = FuzzerTask {
+            task_name: "my fuzzer".to_string(),
+            sub_tasks: vec![
+                EvgTask {
+                    ..Default::default()
+                },
+                EvgTask {
+                    ..Default::default()
+                },
+            ],
+        };
+
+        let task_refs = fuzzer_task.build_task_ref(Some("distro".to_string()));
+
+        for task in task_refs {
+            assert_eq!(task.distros.as_ref(), None);
+        }
     }
 
     // build_name


### PR DESCRIPTION
Ended up not doing too much of refactoring. Added some tests to make sure that distros are applying correctly.

Some patches in evergreen:
https://spruce.mongodb.com/version/63bffc2557e85a1deec2a923
https://spruce.mongodb.com/version/63bffc4361837d7a95e8f92c
https://spruce.mongodb.com/version/63bffd1e9ccd4e371e860fbe

I don't see any failure in patches being related to distros that tasks are running on. I also looked through json configuration files generated by mongo-task-generator in those patches and didn't find any issue with distros as well.