### PR TITLE
DAG-2233 Use the compile variant of burn_in_tag_buildvariant for generating burn_in_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.2 - 2022-01-25
+* Use the compile variant of burn_in_tag_buildvariant for generating burn_in_tags.
+
 ## 0.7.1 - 2022-01-12
 * Apply appropriate large distros to tasks according to build variant configuration.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.1"
+version = "0.7.2"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/docs/generating_tasks.md
+++ b/docs/generating_tasks.md
@@ -200,8 +200,7 @@ of `burn_in_tag_buildvariants` buildvariant expansion:
 
 ```yaml
 burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem enterprise-rhel-80-64-bit-multiversion
-burn_in_tag_compile_distro: rhel80-large
-burn_in_tag_compile_task_group_name: compile_and_archive_dist_test_TG
+burn_in_tag_compile_task_dependency: archive_dist_test_debug
 ```
 
 #### Burn in tasks

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -105,7 +105,7 @@ pre:
 
   - func: cargo_install rust
     vars:
-      rust_version: stable
+      rust_version: 1.66.1
 
   - func: cargo_enable nextest
 

--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -92,8 +92,8 @@ pub const MULTIVERSION_EXCLUDE_TAGS: &str = "multiversion_exclude_tags_version";
 pub const LARGE_DISTRO_EXPANSION: &str = "large_distro_name";
 /// List of build variant names delimited by spaces to generate burn_in_tags for.
 pub const BURN_IN_TAG_BUILD_VARIANTS: &str = "burn_in_tag_buildvariants";
-/// The distro to use when compiling burn_in_tags.
-pub const BURN_IN_TAG_COMPILE_TASK_GROUP_NAME: &str = "burn_in_tag_compile_task_group_name";
+/// Compile task name generated build variant should depend on.
+pub const BURN_IN_TAG_COMPILE_TASK_DEPENDENCY: &str = "burn_in_tag_compile_task_dependency";
 /// Name of build variant to determine the timeouts for.
 pub const BURN_IN_BYPASS: &str = "burn_in_bypass";
 /// List of tasks to burn in.
@@ -128,5 +128,5 @@ pub const LINUX: &str = "linux";
 // Constants in evergreen.yml.
 /// Name of the variant that calls generate.task on the version.
 pub const VERSION_GEN_VARIANT: &str = "generate-tasks-for-version";
-/// Name of the task that calls generate.task on the version.
-pub const VERSION_GEN_TASK: &str = "version_gen";
+/// Name of the task that calls generate.task on the version for burn-in.
+pub const VERSION_BURN_IN_GEN_TASK: &str = "version_burn_in_gen";

--- a/tests/data/burn_in/evergreen_with_empty_burn_in_variants.yml
+++ b/tests/data/burn_in/evergreen_with_empty_burn_in_variants.yml
@@ -156,8 +156,7 @@ buildvariants:
       exec_timeout_factor: 1.5
       large_distro_name: rhel80-medium
       burn_in_tag_buildvariants: 
-      burn_in_tag_compile_distro: rhelx-80
-      burn_in_tag_compile_task_group_name: compile-name
+      burn_in_tag_compile_task_dependency: compile-name
       num_scons_link_jobs_available: 0.99
     tasks:
     - name: burn_in_tags_gen

--- a/tests/data/burn_in/evergreen_with_no_burn_in_task_group.yml
+++ b/tests/data/burn_in/evergreen_with_no_burn_in_task_group.yml
@@ -156,8 +156,7 @@ buildvariants:
       exec_timeout_factor: 1.5
       large_distro_name: rhel80-medium
       burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-dynamic-required
-      burn_in_tag_compile_distro: rhelx-80
-      # burn_in_tag_compile_task_group_name: compile-name
+      # burn_in_tag_compile_task_dependency: compile-name
       num_scons_link_jobs_available: 0.99
     tasks:
     - name: burn_in_tags_gen

--- a/tests/data/burn_in/evergreen_with_no_burn_in_variants.yml
+++ b/tests/data/burn_in/evergreen_with_no_burn_in_variants.yml
@@ -156,8 +156,7 @@ buildvariants:
       exec_timeout_factor: 1.5
       large_distro_name: rhel80-medium
       # burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-dynamic-required
-      burn_in_tag_compile_distro: rhelx-80
-      burn_in_tag_compile_task_group_name: compile-name
+      burn_in_tag_compile_task_dependency: compile-name
       num_scons_link_jobs_available: 0.99
     tasks:
     - name: burn_in_tags_gen

--- a/tests/data/evergreen.yml
+++ b/tests/data/evergreen.yml
@@ -7687,8 +7687,7 @@ buildvariants:
     exec_timeout_factor: 1.5
     large_distro_name: rhel80-medium
     burn_in_tag_buildvariants: enterprise-rhel-80-64-bit-inmem enterprise-rhel-80-64-bit-multiversion
-    burn_in_tag_compile_distro: rhelx-80
-    burn_in_tag_compile_task_group_name: compile-name
+    burn_in_tag_compile_task_dependency: compile-name
     num_scons_link_jobs_available: 0.99
     compile_distro: enterprise-rhel-80-64-bit-dynamic-required
   tasks:

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -71,7 +71,7 @@ fn test_end2end_burn_in_execution() {
 
 #[rstest]
 #[should_panic(
-    expected = "`enterprise-rhel-80-64-bit-dynamic-required` build variant is missing the `burn_in_tag_compile_task_group_name` expansion to run `burn_in_tags_gen`. Set the expansion in your project\\'s config to continue.\\"
+    expected = "`enterprise-rhel-80-64-bit-dynamic-required` build variant is missing the `burn_in_tag_compile_task_dependency` expansion to run `burn_in_tags_gen`. Set the expansion in your project\\'s config to continue.\\"
 )]
 #[case::panic_with_message("tests/data/burn_in/evergreen_with_no_burn_in_task_group.yml")]
 #[should_panic(


### PR DESCRIPTION
Switched the use of compile variant of the variant where the burn_in_tags task is configured to the variant that we base generated burn_in_tags variant off of.

For example we have burn_in_tags_gen task configured on `enterprise-rhel-80-64-bit-dynamic-all-feature-flags-required` variant. The following configuration is setup for this variant:

```
- name: enterprise-rhel-80-64-bit-dynamic-all-feature-flags-required
...
  expansions:
    burn_in_tag_buildvariants: >-
      enterprise-rhel-80-64-bit-inmem
      enterprise-rhel-80-64-bit-multiversion
    burn_in_tag_compile_task_dependency: archive_dist_test_debug
    compile_variant: linux-x86-dynamic-compile-required
```

Instead of using `compile_variant` configuration from this variant we are using configurations from `enterprise-rhel-80-64-bit-inmem` and `enterprise-rhel-80-64-bit-multiversion` variants respectively while generating burn_in_tags variants, which are the following in our case:

```
- name: enterprise-rhel-80-64-bit-inmem
...
  expansions:
    compile_variant: enterprise-rhel-80-64-bit-inmem
```

```
- name: enterprise-rhel-80-64-bit-multiversion
...
  expansions:
    compile_variant: linux-x86-dynamic-compile-required
```

Therefore, for generated `enterprise-rhel-80-64-bit-inmem-required` variant we are using the compile from `enterprise-rhel-80-64-bit-inmem` variant:
- Tasks depend on `archive_dist_test_debug` task from `enterprise-rhel-80-64-bit-inmem` variant, see [task metadata](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_rhel_80_64_bit_inmem_required_burn_in:causally_consistent_hedged_reads_jscore_passthrough_gen_enterprise_rhel_80_64_bit_inmem_required_0_patch_1ad055e4a0028cf4e1745361b1cb1e8423395f08_63d17fcd61837d28ab1e7f28_23_01_25_19_17_09/logs?execution=0&sortBy=STATUS&sortDir=ASC)
- Tasks download compile binaries that were produced by `enterprise-rhel-80-64-bit-inmem` variant, see [task logs](https://parsley.mongodb.com/evergreen/mongodb_mongo_master_enterprise_rhel_80_64_bit_inmem_required_burn_in:causally_consistent_hedged_reads_jscore_passthrough_gen_enterprise_rhel_80_64_bit_inmem_required_0_patch_1ad055e4a0028cf4e1745361b1cb1e8423395f08_63d17fcd61837d28ab1e7f28_23_01_25_19_17_09/0/task?bookmarks=0,3664&shareLine=48)

And for `enterprise-rhel-80-64-bit-multiversion-required` variant we are using the compile from `linux-x86-dynamic-compile-required` variant:
- Tasks depend on `archive_dist_test_debug` task from `linux-x86-dynamic-compile-required` variant, see [task metadata](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_required_burn_in:change_streams_downgrade_last_continuous_new_old_old_new_enterprise_rhel_80_64_bit_multiversion_required_0_patch_1ad055e4a0028cf4e1745361b1cb1e8423395f08_63d17fcd61837d28ab1e7f28_23_01_25_19_17_09/logs?execution=0&sortBy=STATUS&sortDir=ASC)
- Tasks download compile binaries that were produced by `linux-x86-dynamic-compile-required` variant, see [task logs](https://parsley.mongodb.com/evergreen/mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_required_burn_in:change_streams_downgrade_last_continuous_new_old_old_new_enterprise_rhel_80_64_bit_multiversion_required_0_patch_1ad055e4a0028cf4e1745361b1cb1e8423395f08_63d17fcd61837d28ab1e7f28_23_01_25_19_17_09/0/task?bookmarks=0,2866&shareLine=93)

Evergreen patches:
https://spruce.mongodb.com/version/63d17fcd61837d28ab1e7f28 - triggered burn-in
https://spruce.mongodb.com/version/63d180629ccd4e784a26c7bd - regular patch