### PR TITLE
DAG-2404 Pass evergreen file location when calling burn_in_tests.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.3 - 2022-03-30
+* Pass evergreen file location when calling burn_in_tests.py.
+
 ## 0.7.2 - 2022-01-25
 * Use the compile variant of burn_in_tag_buildvariant for generating burn_in_tags.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.2"
+version = "0.7.3"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,10 @@ impl Dependencies {
             execution_config.gen_burn_in,
         ));
 
-        let burn_in_discovery = Arc::new(BurnInProxy::new(execution_config.burn_in_tests_command));
+        let burn_in_discovery = Arc::new(BurnInProxy::new(
+            execution_config.burn_in_tests_command,
+            &execution_config.project_info.evg_project_location,
+        ));
         let burn_in_service = Arc::new(BurnInServiceImpl::new(
             burn_in_discovery,
             gen_resmoke_task_service,


### PR DESCRIPTION
This makes it possible to generate burn-in for projects that uses `etc/evergreen_nightly.yml`

Evergreen patch for mongodb-mongo-master project, that uses `etc/evergreen.yml` (this shows that the current workflow continues to work the same way): https://spruce.mongodb.com/version/642573841e2d1799c1cd7e2f

Evergreen patch for mongodb-mongo-v6.3 project, that uses `etc/evergreen_nightly.yml`:
https://spruce.mongodb.com/version/642572072fbabedd6fa00363