### PR TITLE
DAG-2476 Make resmoke errors easier to see in version_gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.4 - 2022-04-14
+* Make resmoke errors easier to see in version_gen.
+
 ## 0.7.3 - 2022-03-30
 * Pass evergreen file location when calling burn_in_tests.py.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.3"
+version = "0.7.4"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/resmoke/external_cmd.rs
+++ b/src/resmoke/external_cmd.rs
@@ -34,7 +34,7 @@ pub fn run_command(command: &[&str]) -> Result<String> {
             stdout = regular_info,
             "Command encountered an error",
         );
-        bail!("Command encountered an error")
+        bail!(error_message)
     }
 
     let output = String::from_utf8_lossy(&cmd.stdout);


### PR DESCRIPTION
https://jira.mongodb.org/browse/DAG-2476

Currently, when resmoke throws an exception, the stack traceback is logged as one line, which makes it difficult to see. This, PR implements a change that prints each line of traceback in a separate line, to make it more readable. The original logging remains the same.

Before:
![Screenshot 2023-04-13 at 11 44 12 AM](https://user-images.githubusercontent.com/121054225/231830009-3b6e4d8e-ce09-4d98-b8dc-bdf51bbae8b3.png)

After:
![Screenshot 2023-04-13 at 11 43 30 AM](https://user-images.githubusercontent.com/121054225/231830055-4c641900-14b0-42d6-a019-86c2a8b1bdfb.png)
