### PR TITLE
SERVER-74832 Resmoke description field does not work for suites that get split up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.7.6 - 2022-05-02
-* Add description to subsuites
+* Add description and matrix_suite to subsuites
 
 ## 0.7.5 - 2022-04-25
 * Upgrade build artifact for github runner service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.7.6 - 2022-05-02
-* Add description and matrix_suite to subsuites
+* Pass suite description and matrix_suite to subsuites
 
 ## 0.7.5 - 2022-04-25
 * Upgrade build artifact for github runner service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.6 - 2022-05-02
+* Add description to subsuites
+
 ## 0.7.5 - 2022-04-25
 * Upgrade build artifact for github runner service
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.5"
+version = "0.7.6"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/resmoke/resmoke_suite.rs
+++ b/src/resmoke/resmoke_suite.rs
@@ -81,6 +81,7 @@ pub struct ResmokeExecutor {
 /// Configuration of a resmoke test suite.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResmokeSuiteConfig {
+    pub matrix_suite: bool,
     pub description: String,
     pub test_kind: String,
     pub selector: ResmokeSelector,
@@ -188,6 +189,8 @@ mod tests {
         let config_yaml = "
             description: Task description
 
+            matrix_suite: true
+
             test_kind: js_test
 
             selector:
@@ -214,6 +217,8 @@ mod tests {
     fn test_shared_cluster_fixture_should_return_sharded() {
         let config_yaml = "
             description: Task description
+
+            matrix_suite: true
 
             test_kind: js_test
 
@@ -245,6 +250,8 @@ mod tests {
         let config_yaml = "
             description: Task description
 
+            matrix_suite: true
+
             test_kind: js_test
 
             selector:
@@ -274,6 +281,8 @@ mod tests {
     fn test_other_fixture_should_return_other() {
         let config_yaml = "
             description: Task description
+
+            matrix_suite: true
 
             test_kind: js_test
 
@@ -305,6 +314,8 @@ mod tests {
     fn test_with_new_tests_can_add_tests_to_exclude_list() {
         let config_yaml = "
             description: Task description
+
+            matrix_suite: true
 
             test_kind: js_test
 
@@ -340,6 +351,8 @@ mod tests {
     fn test_with_new_tests_can_add_tests_to_test_root() {
         let config_yaml = "
             description: Task description
+
+            matrix_suite: true
 
             test_kind: js_test
 

--- a/src/resmoke/resmoke_suite.rs
+++ b/src/resmoke/resmoke_suite.rs
@@ -186,6 +186,8 @@ mod tests {
     #[test]
     fn test_no_fixture_defined_should_return_shell() {
         let config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:
@@ -211,6 +213,8 @@ mod tests {
     #[test]
     fn test_shared_cluster_fixture_should_return_sharded() {
         let config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:
@@ -239,6 +243,8 @@ mod tests {
     #[test]
     fn test_replica_set_fixture_should_return_repl() {
         let config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:
@@ -267,6 +273,8 @@ mod tests {
     #[test]
     fn test_other_fixture_should_return_other() {
         let config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:
@@ -296,6 +304,8 @@ mod tests {
     #[test]
     fn test_with_new_tests_can_add_tests_to_exclude_list() {
         let config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:
@@ -329,6 +339,8 @@ mod tests {
     #[test]
     fn test_with_new_tests_can_add_tests_to_test_root() {
         let config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:

--- a/src/resmoke/resmoke_suite.rs
+++ b/src/resmoke/resmoke_suite.rs
@@ -81,8 +81,10 @@ pub struct ResmokeExecutor {
 /// Configuration of a resmoke test suite.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResmokeSuiteConfig {
-    pub matrix_suite: bool,
-    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matrix_suite: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub test_kind: String,
     pub selector: ResmokeSelector,
     pub executor: ResmokeExecutor,
@@ -187,10 +189,6 @@ mod tests {
     #[test]
     fn test_no_fixture_defined_should_return_shell() {
         let config_yaml = "
-            description: Task description
-
-            matrix_suite: true
-
             test_kind: js_test
 
             selector:
@@ -216,10 +214,6 @@ mod tests {
     #[test]
     fn test_shared_cluster_fixture_should_return_sharded() {
         let config_yaml = "
-            description: Task description
-
-            matrix_suite: true
-
             test_kind: js_test
 
             selector:
@@ -248,7 +242,7 @@ mod tests {
     #[test]
     fn test_replica_set_fixture_should_return_repl() {
         let config_yaml = "
-            description: Task description
+            description: Suite description
 
             matrix_suite: true
 
@@ -280,10 +274,6 @@ mod tests {
     #[test]
     fn test_other_fixture_should_return_other() {
         let config_yaml = "
-            description: Task description
-
-            matrix_suite: true
-
             test_kind: js_test
 
             selector:
@@ -313,10 +303,6 @@ mod tests {
     #[test]
     fn test_with_new_tests_can_add_tests_to_exclude_list() {
         let config_yaml = "
-            description: Task description
-
-            matrix_suite: true
-
             test_kind: js_test
 
             selector:
@@ -350,10 +336,6 @@ mod tests {
     #[test]
     fn test_with_new_tests_can_add_tests_to_test_root() {
         let config_yaml = "
-            description: Task description
-
-            matrix_suite: true
-
             test_kind: js_test
 
             selector:

--- a/src/resmoke/resmoke_suite.rs
+++ b/src/resmoke/resmoke_suite.rs
@@ -81,6 +81,7 @@ pub struct ResmokeExecutor {
 /// Configuration of a resmoke test suite.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResmokeSuiteConfig {
+    pub description: String,
     pub test_kind: String,
     pub selector: ResmokeSelector,
     pub executor: ResmokeExecutor,

--- a/src/task_types/multiversion.rs
+++ b/src/task_types/multiversion.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_multiversion_iterator() {
         let suite_config_yaml = "
-            description: Task description
+            description: Suite description
 
             matrix_suite: true
 
@@ -338,10 +338,6 @@ mod tests {
     #[test]
     fn test_mv_get_version_combinations() {
         let suite_config_yaml = "
-            description: Task description
-
-            matrix_suite: true
-
             test_kind: js_test
 
             selector:

--- a/src/task_types/multiversion.rs
+++ b/src/task_types/multiversion.rs
@@ -298,6 +298,8 @@ mod tests {
     #[test]
     fn test_multiversion_iterator() {
         let suite_config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:
@@ -334,6 +336,8 @@ mod tests {
     #[test]
     fn test_mv_get_version_combinations() {
         let suite_config_yaml = "
+            description: Task description
+
             test_kind: js_test
 
             selector:

--- a/src/task_types/multiversion.rs
+++ b/src/task_types/multiversion.rs
@@ -300,6 +300,8 @@ mod tests {
         let suite_config_yaml = "
             description: Task description
 
+            matrix_suite: true
+
             test_kind: js_test
 
             selector:
@@ -337,6 +339,8 @@ mod tests {
     fn test_mv_get_version_combinations() {
         let suite_config_yaml = "
             description: Task description
+
+            matrix_suite: true
 
             test_kind: js_test
 

--- a/src/task_types/resmoke_config_writer.rs
+++ b/src/task_types/resmoke_config_writer.rs
@@ -315,6 +315,8 @@ mod tests {
             _suite_name: &str,
         ) -> anyhow::Result<crate::resmoke::resmoke_suite::ResmokeSuiteConfig> {
             let sample_config = "
+                description: Task description
+
                 test_kind: js_test
 
                 selector:

--- a/src/task_types/resmoke_config_writer.rs
+++ b/src/task_types/resmoke_config_writer.rs
@@ -315,7 +315,7 @@ mod tests {
             _suite_name: &str,
         ) -> anyhow::Result<crate::resmoke::resmoke_suite::ResmokeSuiteConfig> {
             let sample_config = "
-                description: Task description
+                description: Suite description
 
                 matrix_suite: true
 

--- a/src/task_types/resmoke_config_writer.rs
+++ b/src/task_types/resmoke_config_writer.rs
@@ -317,6 +317,8 @@ mod tests {
             let sample_config = "
                 description: Task description
 
+                matrix_suite: true
+
                 test_kind: js_test
 
                 selector:

--- a/tests/mocks/resmoke.py
+++ b/tests/mocks/resmoke.py
@@ -13,7 +13,7 @@ requires_fcv_tag: requires_fcv_51,requires_fcv_52,requires_fcv_53,requires_fcv_6
 
 def suiteconfig():
     print("""
-description: Task description
+description: Suite description
 
 matrix_suite: true
 

--- a/tests/mocks/resmoke.py
+++ b/tests/mocks/resmoke.py
@@ -15,6 +15,8 @@ def suiteconfig():
     print("""
 description: Task description
 
+matrix_suite: true
+
 test_kind: js_test
 
 selector:

--- a/tests/mocks/resmoke.py
+++ b/tests/mocks/resmoke.py
@@ -13,6 +13,8 @@ requires_fcv_tag: requires_fcv_51,requires_fcv_52,requires_fcv_53,requires_fcv_6
 
 def suiteconfig():
     print("""
+description: Task description
+
 test_kind: js_test
 
 selector:


### PR DESCRIPTION
https://jira.mongodb.org/browse/SERVER-74832

This PR introduces changes to propagate description of a suite to its sub-suites when a task is split using task-generator

Patch Build before changes:
https://spruce.mongodb.com/version/645175087742ae5f18f7a73b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Patch Build after changes:
https://spruce.mongodb.com/version/64517d633e8e866fe3584115/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Before:
![Screenshot 2023-05-05 at 9 09 55 AM](https://user-images.githubusercontent.com/121054225/236482703-9e1f8d8e-8078-4234-b799-833b076df2f6.png)


After:
![Screenshot 2023-05-05 at 9 08 07 AM](https://user-images.githubusercontent.com/121054225/236482755-f7cfb0fc-06f6-43f0-b6ef-3ae37e9fea83.png)

