### PR TITLE
SERVER-78190 Establish mechanism for changing task split logic

### DIFF
--- a/src/evergreen/evg_task_history.rs
+++ b/src/evergreen/evg_task_history.rs
@@ -24,6 +24,8 @@ pub struct S3TestStats {
     pub num_fail: u64,
     /// Average duration of passed tests.
     pub avg_duration_pass: f64,
+    /// Max duration of test, in seconds
+    pub max_duration_pass: f64,
 }
 
 /// Runtime information of hooks that ran in evergreen.
@@ -35,6 +37,8 @@ pub struct HookRuntimeHistory {
     pub hook_name: String,
     /// Average runtime of hook.
     pub average_runtime: f64,
+    /// Max duration of test, in seconds
+    pub max_duration_pass: f64,
 }
 
 impl Display for HookRuntimeHistory {
@@ -271,6 +275,7 @@ fn gather_hook_stats(stat_list: &[S3TestStats]) -> HashMap<String, Vec<HookRunti
                     test_name: test_name.to_string(),
                     hook_name: hook_name.to_string(),
                     average_runtime: stat.avg_duration_pass,
+                    max_duration_pass: stat.max_duration_pass,
                 });
             } else {
                 hook_map.insert(
@@ -279,6 +284,7 @@ fn gather_hook_stats(stat_list: &[S3TestStats]) -> HashMap<String, Vec<HookRunti
                         test_name: test_name.to_string(),
                         hook_name: hook_name.to_string(),
                         average_runtime: stat.avg_duration_pass,
+                        max_duration_pass: stat.max_duration_pass,
                     }],
                 );
             }

--- a/src/evergreen/evg_task_history.rs
+++ b/src/evergreen/evg_task_history.rs
@@ -54,6 +54,8 @@ pub struct TestRuntimeHistory {
     pub test_name: String,
     /// Average runtime of test.
     pub average_runtime: f64,
+    /// Max duration of test, in seconds
+    pub max_duration_pass: f64,
     /// Hooks runtime information of hooks that ran with the test.
     pub hooks: Vec<HookRuntimeHistory>,
 }
@@ -234,6 +236,7 @@ fn gather_test_stats(
                     TestRuntimeHistory {
                         test_name: normalized_test_file,
                         average_runtime: stat.avg_duration_pass,
+                        max_duration_pass: 0.0,
                         hooks: hook_map
                             .get(&test_name.to_string())
                             .unwrap_or(&vec![])

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -382,6 +382,11 @@ enum PreferredStatForSplitTask {
     MaxDuration,
 }
 
+fn select_preferred_stat() -> PreferredStatForSplitTask {
+    // TODO: Figure out the selection logic
+    return PreferredStatForSplitTask::AverageRuntime;
+}
+
 impl GenResmokeTaskServiceImpl {
     /// Split the given task into a number of sub-tasks for parallel execution.
     ///
@@ -579,13 +584,14 @@ impl GenResmokeTaskServiceImpl {
     ) -> Result<Vec<SubSuite>> {
         let mut mv_sub_suites = vec![];
         for multiversion_task in params.multiversion_generate_tasks.as_ref().unwrap() {
+            let preferred_stat = select_preferred_stat();
             let suites = self
                 .create_tasks(
                     params,
                     build_variant,
                     Some(&multiversion_task.suite_name.clone()),
                     Some(multiversion_task.old_version.clone()),
-                    PreferredStatForSplitTask::AverageRuntime,
+                    preferred_stat,
                 )
                 .await?;
             mv_sub_suites.extend_from_slice(&suites);
@@ -731,7 +737,8 @@ impl GenResmokeTaskService for GenResmokeTaskServiceImpl {
             self.create_multiversion_tasks(params, build_variant)
                 .await?
         } else {
-            self.create_tasks(params, build_variant, None, None, PreferredStatForSplitTask::AverageRuntime).await?
+            let preferred_stat = select_preferred_stat();
+            self.create_tasks(params, build_variant, None, None, preferred_stat).await?
         };
 
         let sub_task_total = sub_suites.len();

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -653,6 +653,7 @@ fn sort_tests_by_runtime(
         let default_runtime = TestRuntimeHistory {
             test_name: "default".to_string(),
             average_runtime: 0.0,
+            max_duration_pass: 0.0,
             hooks: vec![],
         };
         let runtime_history_a = task_stats
@@ -1132,6 +1133,7 @@ mod tests {
         TestRuntimeHistory {
             test_name: test_name.to_string(),
             average_runtime: runtime,
+            max_duration_pass: 0.0,
             hooks: vec![],
         }
     }

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -1135,11 +1135,11 @@ mod tests {
         )
     }
 
-    fn build_mock_test_runtime(test_name: &str, runtime: f64) -> TestRuntimeHistory {
+    fn build_mock_test_runtime(test_name: &str, runtime: f64, max_duration: f64) -> TestRuntimeHistory {
         TestRuntimeHistory {
             test_name: test_name.to_string(),
             average_runtime: runtime,
-            max_duration_pass: 0.0,
+            max_duration_pass: max_duration,
             hooks: vec![],
         }
     }
@@ -1157,12 +1157,12 @@ mod tests {
         let task_history = TaskRuntimeHistory {
             task_name: "my task".to_string(),
             test_map: hashmap! {
-                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0),
-                "test_1".to_string() => build_mock_test_runtime("test_1.js", 56.0),
-                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0),
-                "test_3".to_string() => build_mock_test_runtime("test_3.js", 35.0),
-                "test_4".to_string() => build_mock_test_runtime("test_4.js", 34.0),
-                "test_5".to_string() => build_mock_test_runtime("test_5.js", 30.0),
+                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0, 0.0),
+                "test_1".to_string() => build_mock_test_runtime("test_1.js", 56.0, 0.0),
+                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0, 0.0),
+                "test_3".to_string() => build_mock_test_runtime("test_3.js", 35.0, 0.0),
+                "test_4".to_string() => build_mock_test_runtime("test_4.js", 34.0, 0.0),
+                "test_5".to_string() => build_mock_test_runtime("test_5.js", 30.0, 0.0),
             },
         };
         let gen_resmoke_service =
@@ -1198,9 +1198,9 @@ mod tests {
         let task_history = TaskRuntimeHistory {
             task_name: "my task".to_string(),
             test_map: hashmap! {
-                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0),
-                "test_1".to_string() => build_mock_test_runtime("test_1.js", 50.0),
-                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0),
+                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0, 0.0),
+                "test_1".to_string() => build_mock_test_runtime("test_1.js", 50.0, 0.0),
+                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0, 0.0),
             },
         };
         let gen_resmoke_service = build_mocked_service(test_list, task_history.clone(), n_suites);
@@ -1232,9 +1232,9 @@ mod tests {
         let task_history = TaskRuntimeHistory {
             task_name: "my task".to_string(),
             test_map: hashmap! {
-                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0),
-                "test_1".to_string() => build_mock_test_runtime("test_1.js", 50.0),
-                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0),
+                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0, 0.0),
+                "test_1".to_string() => build_mock_test_runtime("test_1.js", 50.0, 0.0),
+                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0, 0.0),
             },
         };
         let gen_resmoke_service = build_mocked_service(test_list, task_history.clone(), n_suites);
@@ -1448,12 +1448,12 @@ mod tests {
         let task_history = TaskRuntimeHistory {
             task_name: "my_task".to_string(),
             test_map: hashmap! {
-                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0),
-                "test_1".to_string() => build_mock_test_runtime("test_1.js", 50.0),
-                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0),
-                "test_3".to_string() => build_mock_test_runtime("test_3.js", 34.0),
-                "test_4".to_string() => build_mock_test_runtime("test_4.js", 34.0),
-                "test_5".to_string() => build_mock_test_runtime("test_5.js", 34.0),
+                "test_0".to_string() => build_mock_test_runtime("test_0.js", 100.0, 0.0),
+                "test_1".to_string() => build_mock_test_runtime("test_1.js", 50.0, 0.0),
+                "test_2".to_string() => build_mock_test_runtime("test_2.js", 50.0, 0.0),
+                "test_3".to_string() => build_mock_test_runtime("test_3.js", 34.0, 0.0),
+                "test_4".to_string() => build_mock_test_runtime("test_4.js", 34.0, 0.0),
+                "test_5".to_string() => build_mock_test_runtime("test_5.js", 34.0, 0.0),
             },
         };
         let gen_resmoke_service = build_mocked_service(test_list, task_history.clone(), n_suites);
@@ -1598,6 +1598,7 @@ mod tests {
                         build_mock_test_runtime(
                             format!("test_{}.js", i).as_ref(),
                             historic_runtimes[i],
+                            0.0,
                         ),
                     )
                 })


### PR DESCRIPTION
This PR establishes the plumbing to change how resmoke splits up a task. It adds an option to based the task-splitting on max duration, instead of average runtime.

Note that the PR does not actually leverage the new option; the implementation of `select_preferred_stat()` unconditionally returns `AverageRuntime`.