### PR TITLE
DEVPROD-5087 allow variants to override last_versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.12 - 2024-02-29
+* DEVPROD-5087 allow variants to override last_versions
+
 ## 0.7.11 - 2024-02-16
 * DEVPROD-4926 add use_xlarge_distro option to mongo-task-generator
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.11"
+version = "0.7.12"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -110,6 +110,10 @@ pub const BURN_IN_TAG_COMPILE_TASK_DEPENDENCY: &str = "burn_in_tag_compile_task_
 pub const BURN_IN_BYPASS: &str = "burn_in_bypass";
 /// List of tasks to burn in.
 pub const BURN_IN_TASK_NAME: &str = "burn_in_task_name";
+/// Variant specific override of last_versions in the multiversion-config
+pub const LAST_VERSIONS_EXPANSION: &str = "last_versions";
+/// Unique identifier for generated tasks to use that override last_versions
+pub const UNIQUE_GEN_SUFFIX_EXPANSION: &str = "unique_gen_suffix";
 
 // Task Tags
 /// Tag to include multiversion setup is required.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,14 +787,14 @@ fn lookup_task_name(
             task_name,
             platform,
             ENTERPRISE_MODULE,
-            unique_gen_suffix.unwrap_or("".to_string())
+            unique_gen_suffix.as_deref().unwrap_or("")
         )
     } else {
         format!(
             "{}-{}{}",
             task_name,
             platform,
-            unique_gen_suffix.unwrap_or("".to_string())
+            unique_gen_suffix.as_deref().unwrap_or("")
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,7 +495,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 {
                     continue;
                 }
-                let last_versions_expansion = self
+                let gen_task_suffix = self
                     .evg_config_utils
                     .lookup_build_variant_expansion(UNIQUE_GEN_SUFFIX_EXPANSION, build_variant);
                 // Skip tasks that have already been seen.
@@ -503,7 +503,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                     is_enterprise,
                     &task.name,
                     &platform,
-                    last_versions_expansion.as_deref(),
+                    gen_task_suffix.as_deref(),
                 );
                 if seen_tasks.contains(&task_name) {
                     continue;
@@ -691,14 +691,14 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                 } else if task.name == BURN_IN_TASKS {
                     format!("{}-{}", BURN_IN_TASKS_PREFIX, bv_name)
                 } else {
-                    let last_versions_expansion = self
+                    let gen_task_suffix = self
                         .evg_config_utils
                         .lookup_build_variant_expansion(UNIQUE_GEN_SUFFIX_EXPANSION, build_variant);
                     lookup_task_name(
                         is_enterprise,
                         &task.name,
                         &platform,
-                        last_versions_expansion.as_deref(),
+                        gen_task_suffix.as_deref(),
                     )
                 };
 
@@ -831,13 +831,13 @@ fn create_task_worker(
 
         let is_enterprise = evg_config_utils.is_enterprise_build_variant(&build_variant);
         let platform = evg_config_utils.infer_build_variant_platform(&build_variant);
-        let last_versions_expansion = evg_config_utils
+        let gen_task_suffix = evg_config_utils
             .lookup_build_variant_expansion(UNIQUE_GEN_SUFFIX_EXPANSION, &build_variant);
         let task_name = lookup_task_name(
             is_enterprise,
             &task_def.name,
             &platform,
-            last_versions_expansion.as_deref(),
+            gen_task_suffix.as_deref(),
         );
 
         if let Some(generated_task) = generated_task {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                     is_enterprise,
                     &task.name,
                     &platform,
-                    last_versions_expansion,
+                    last_versions_expansion.as_deref(),
                 );
                 if seen_tasks.contains(&task_name) {
                     continue;
@@ -698,7 +698,7 @@ impl GenerateTasksService for GenerateTasksServiceImpl {
                         is_enterprise,
                         &task.name,
                         &platform,
-                        last_versions_expansion,
+                        last_versions_expansion.as_deref(),
                     )
                 };
 
@@ -779,7 +779,7 @@ fn lookup_task_name(
     is_enterprise: bool,
     task_name: &str,
     platform: &str,
-    unique_gen_suffix: Option<String>,
+    unique_gen_suffix: Option<&str>,
 ) -> String {
     if is_enterprise {
         format!(
@@ -787,14 +787,14 @@ fn lookup_task_name(
             task_name,
             platform,
             ENTERPRISE_MODULE,
-            unique_gen_suffix.as_deref().unwrap_or("")
+            unique_gen_suffix.unwrap_or("")
         )
     } else {
         format!(
             "{}-{}{}",
             task_name,
             platform,
-            unique_gen_suffix.as_deref().unwrap_or("")
+            unique_gen_suffix.unwrap_or("")
         )
     }
 }
@@ -837,7 +837,7 @@ fn create_task_worker(
             is_enterprise,
             &task_def.name,
             &platform,
-            last_versions_expansion,
+            last_versions_expansion.as_deref(),
         );
 
         if let Some(generated_task) = generated_task {

--- a/src/task_types/burn_in_tests.rs
+++ b/src/task_types/burn_in_tests.rs
@@ -202,7 +202,7 @@ impl BurnInServiceImpl {
         for (index, test) in discovered_task.test_list.iter().enumerate() {
             let mut params = self
                 .config_extraction_service
-                .task_def_to_resmoke_params(task_def, false, None)?;
+                .task_def_to_resmoke_params(task_def, false, None, None)?;
             update_resmoke_params_for_burn_in(&mut params, test);
 
             if params.require_multiversion_generate_tasks {
@@ -253,7 +253,7 @@ impl BurnInServiceImpl {
         for index in 0..BURN_IN_REPEAT_TASK_NUM {
             let params = self
                 .config_extraction_service
-                .task_def_to_resmoke_params(task_def, false, None)?;
+                .task_def_to_resmoke_params(task_def, false, None, None)?;
 
             if params.require_multiversion_generate_tasks {
                 for multiversion_task in params.multiversion_generate_tasks.as_ref().unwrap() {
@@ -663,6 +663,7 @@ mod tests {
             &self,
             _task_def: &EvgTask,
             _is_enterprise: bool,
+            _build_variant: Option<&BuildVariant>,
             _platform: Option<String>,
         ) -> Result<ResmokeGenParams> {
             Ok(ResmokeGenParams {
@@ -688,6 +689,7 @@ mod tests {
         fn filter_multiversion_generate_tasks(
             &self,
             multiversion_generate_tasks: Option<Vec<MultiversionGenerateTaskConfig>>,
+            _last_versions_expansion: Option<String>,
         ) -> Option<Vec<MultiversionGenerateTaskConfig>> {
             return multiversion_generate_tasks;
         }

--- a/src/task_types/fuzzer_tasks.rs
+++ b/src/task_types/fuzzer_tasks.rs
@@ -62,6 +62,8 @@ pub struct FuzzerGenTaskParams {
     pub is_enterprise: bool,
     /// Name of platform the task will run on.
     pub platform: Option<String>,
+    /// Name of variant specific suffix to add to tasks
+    pub gen_task_suffix: Option<String>,
 }
 
 impl FuzzerGenTaskParams {
@@ -291,8 +293,14 @@ fn build_fuzzer_sub_task(
         ),
     ]);
 
+    let formatted_name = format!(
+        "{}{}",
+        sub_task_name,
+        params.gen_task_suffix.as_deref().unwrap_or("")
+    );
+
     EvgTask {
-        name: sub_task_name,
+        name: formatted_name,
         commands: Some(commands),
         depends_on: params.get_dependencies(),
         ..Default::default()

--- a/src/task_types/multiversion.rs
+++ b/src/task_types/multiversion.rs
@@ -126,7 +126,7 @@ impl MultiversionService for MultiversionServiceImpl {
         last_versions_expansion: Option<String>,
     ) -> Option<Vec<MultiversionGenerateTaskConfig>> {
         let last_versions: Vec<String> = last_versions_expansion
-            .unwrap_or(self.multiversion_config.last_versions.join(","))
+            .unwrap_or_else(|| self.multiversion_config.last_versions.join(","))
             .split(',')
             .map(|s| s.to_string())
             .collect();

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -74,6 +74,8 @@ pub struct ResmokeGenParams {
     pub pass_through_vars: Option<HashMap<String, ParamValue>>,
     /// Name of platform the task will run on.
     pub platform: Option<String>,
+    /// Name of variant specific suffix to add to tasks
+    pub gen_task_suffix: Option<String>,
 }
 
 impl ResmokeGenParams {
@@ -766,9 +768,14 @@ impl GenResmokeTaskService for GenResmokeTaskServiceImpl {
         let run_test_vars =
             params.build_run_test_vars(&suite_file, sub_suite, &exclude_tags, suite_override);
 
+        let formatted_name = format!(
+            "{}{}",
+            suite_file,
+            params.gen_task_suffix.as_deref().unwrap_or("")
+        );
         GeneratedSubTask {
             evg_task: EvgTask {
-                name: suite_file,
+                name: formatted_name,
                 commands: Some(resmoke_commands(
                     RUN_GENERATED_TESTS,
                     run_test_vars,
@@ -1102,6 +1109,7 @@ mod tests {
         fn filter_multiversion_generate_tasks(
             &self,
             multiversion_generate_tasks: Option<Vec<MultiversionGenerateTaskConfig>>,
+            _last_versions_expansion: Option<String>,
         ) -> Option<Vec<MultiversionGenerateTaskConfig>> {
             return multiversion_generate_tasks;
         }


### PR DESCRIPTION
Rust noob

Our git future multiversion variant would not run last continuous tests when last_lts = last_continuous. This allows variants to override the `last_versions` setting in the multiversion_config so they will always have the versions they want.

The UNIQUE_GEN_SUFFIX_EXPANSION is needed so we do not have duplicate tasks with the same name because there can now be conflicts.

Here is a PB on the mongodb-mongo-master project with this implemented: https://spruce.mongodb.com/version/65de6b463e8e8682d69db4f4

The mongo changes for this are here https://github.com/10gen/mongo/pull/19452