### PR TITLE
SERVER-88917 Update method for determining enterprise build variants …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.13 - 2024-04-08
+* SERVER-88917 Update method for determining enterprise build variants without using modules in mongo-task-generator
+
 ## 0.7.12 - 2024-02-29
 * DEVPROD-5087 allow variants to override last_versions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.12"
+version = "0.7.13"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/evergreen/evg_config_utils.rs
+++ b/src/evergreen/evg_config_utils.rs
@@ -7,12 +7,11 @@ use regex::Regex;
 use shrub_rs::models::commands::EvgCommand::Function;
 use shrub_rs::models::params::ParamValue;
 use shrub_rs::models::{commands::FunctionCall, task::EvgTask, variant::BuildVariant};
-use std::collections::BTreeMap;
 
 use crate::evergreen_names::{
     BURN_IN_TAG_EXCLUDE_BUILD_VARIANTS, BURN_IN_TAG_INCLUDE_ALL_REQUIRED_AND_SUGGESTED,
-    BURN_IN_TAG_INCLUDE_BUILD_VARIANTS, GENERATE_RESMOKE_TASKS,
-    INITIALIZE_MULTIVERSION_TASKS, IS_FUZZER, LINUX, MACOS, RUN_RESMOKE_TESTS, WINDOWS,
+    BURN_IN_TAG_INCLUDE_BUILD_VARIANTS, GENERATE_RESMOKE_TASKS, INITIALIZE_MULTIVERSION_TASKS,
+    IS_FUZZER, LINUX, MACOS, RUN_RESMOKE_TESTS, WINDOWS,
 };
 use crate::utils::task_name::remove_gen_suffix;
 
@@ -726,7 +725,7 @@ impl EvgConfigUtils for EvgConfigUtilsImpl {
                 }
             }
         }
-        return true
+        true
     }
 
     /// Infer platform that build variant will run on.
@@ -1739,12 +1738,10 @@ mod tests {
         #[case] modules: Option<Vec<String>>,
     ) {
         let build_variant = BuildVariant {
-            expansions: Some(BTreeMap::from([
-                (
-                    "enterprise_test_flag".to_string(),
-                    "--enableEnterpriseTests=off".to_string(),
-                ),
-            ])),
+            expansions: Some(BTreeMap::from([(
+                "enterprise_test_flag".to_string(),
+                "--enableEnterpriseTests=off".to_string(),
+            )])),
             ..Default::default()
         };
         let evg_config_utils = EvgConfigUtilsImpl::new();


### PR DESCRIPTION
…without using modules in mongo-task-generator

We previously determined if a build variant was an enterprise module by checking for the presence of 'enterprise' in the build variant's modules parameter. Since the removal of the modules:enterprise, we need to have a new method for this determination. I am using regex to match `--enableEnterpriseTests = off` flag. 

I have modified [`prelude_mongo_task_generator.sh`](https://github.com/10gen/mongo/blob/master/evergreen/prelude_mongo_task_generator.sh) file to run tests. 

I have confirmed that we have `-enterprise` for enterprise build variants. Now
<img width="1148" alt="image" src="https://github.com/mongodb/mongo-task-generator/assets/111318390/b7130d3d-96fd-4233-a246-baadf0e0613e">
vs Before
<img width="1186" alt="image" src="https://github.com/mongodb/mongo-task-generator/assets/111318390/263dd55c-25f3-4f59-b252-d3efb73fbc5d">


Here is the [PB](https://spruce.mongodb.com/version/661467314dc692000702edd9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)