### PR TITLE
DEVPROD-9236 Update burn-in task generation to handle each multiversion sub-suite individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.15 - 2024-06-25
+* DEVPROD-9236 Update burn-in task generation to handle each multiversion sub-suite individually
+
 ## 0.7.14 - 2024-05-08
 * DEVPROD-7218 Update shrub-rs dependency that includes downstream_expansions.set command
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.14"
+version = "0.7.15"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/evergreen/evg_config_utils.rs
+++ b/src/evergreen/evg_config_utils.rs
@@ -1735,7 +1735,7 @@ mod tests {
     #[case(Some(vec!["Another Module".to_string(), "Not Enterprise".to_string()]))]
     #[case(None)]
     fn test_build_variant_with_out_enterprise_module_should_return_false(
-        #[case] modules: Option<Vec<String>>,
+        #[case] _modules: Option<Vec<String>>,
     ) {
         let build_variant = BuildVariant {
             expansions: Some(BTreeMap::from([(

--- a/src/resmoke/burn_in_proxy.rs
+++ b/src/resmoke/burn_in_proxy.rs
@@ -8,11 +8,20 @@ use crate::resmoke::external_cmd::run_command;
 
 /// Task that burn_in discovered should be run.
 #[derive(Debug, Clone, Deserialize)]
+pub struct DiscoveredSuite {
+    /// Name of suite to run.
+    pub suite_name: String,
+    /// List of tests to run as part of task.
+    pub test_list: Vec<String>,
+}
+
+/// Task that burn_in discovered should be run.
+#[derive(Debug, Clone, Deserialize)]
 pub struct DiscoveredTask {
     /// Name of task to run.
     pub task_name: String,
-    /// List of tests to run as part of task.
-    pub test_list: Vec<String>,
+    /// List of suites to run as part of task.
+    pub suites: Vec<DiscoveredSuite>,
 }
 
 /// List of tasks that should be run as part of burn_in.

--- a/src/task_types/burn_in_tests.rs
+++ b/src/task_types/burn_in_tests.rs
@@ -199,9 +199,8 @@ impl BurnInServiceImpl {
         run_build_variant: &str,
     ) -> Result<Vec<GeneratedSubTask>> {
         let mut sub_suites = vec![];
-        let mut index = 0;
         for suite in discovered_task.suites.iter() {
-            for test in suite.test_list.iter() {
+            for (index, test) in suite.test_list.iter().enumerate() {
                 let mut params = self
                     .config_extraction_service
                     .task_def_to_resmoke_params(task_def, false, None, None)?;
@@ -232,8 +231,6 @@ impl BurnInServiceImpl {
                     };
                     sub_suites.push(self.create_task(&params, index, &burn_in_suite_info))
                 }
-
-                index += 1;
             }
         }
 

--- a/tests/mocks/burn_in_tests.py
+++ b/tests/mocks/burn_in_tests.py
@@ -3,14 +3,20 @@ def burn_in_discovery():
     print("""
 discovered_tasks:
 - task_name: jsCore
-  test_list:
-  - tests/data/tests/test_0.js
+  suites:
+    - suite_name: jsCore
+      test_list:
+      - tests/data/tests/test_0.js
 - task_name: sharding_jscore_passthrough
-  test_list:
-  - tests/data/tests/test_0.js
+  suites:
+    - suite_name: sharding_jscore_passthrough
+      test_list:
+      - tests/data/tests/test_0.js
 - task_name: replica_sets_jscore_passthrough
-  test_list:
-  - tests/data/tests/test_0.js
+  suites:
+    - suite_name: replica_sets_jscore_passthrough
+      test_list:
+      - tests/data/tests/test_0.js
     """)
 
 


### PR DESCRIPTION
This supports the change of the output format of `buildscripts/burn_in_tests.py run --yaml` that will be done in [SERVER-91556](https://jira.mongodb.org/browse/SERVER-91556)

from 
```yaml
discovered_tasks:
- task_name: jsCore
  test_list:
  - tests/data/tests/test_0.js
```

to
```yaml
discovered_tasks:
- task_name: jsCore
  suites:
  - suite_name: jsCore
    test_list:
    - tests/data/tests/test_0.js
```

This way it generates only affected multiversion sub suites.

🌲 https://spruce.mongodb.com/version/669f8820b5f6690007ef9990 - before
🌲 https://spruce.mongodb.com/version/66a24531e80fa500070be58b - after