### PR TITLE
DEVPROD-12834 Update shrub-rs dependency that includes ec2.assume_role command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.19 - 2024-11-18
+* DEVPROD-11914 Update shrub-rs dependency that includes ec2.assume_role command
+
 ## 0.7.18 - 2024-10-11
 * DEVPROD-11978 use --skipTestsCoveredByMoreComplexSuites when generating tasks in a patch build.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2892,9 +2892,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shrub-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed324b842f9f8da788311898351f992739c58c2127b612f8c9ae3858012dc5e7"
+checksum = "23eefe73155207d228f19f029620cb44a581c6e5364927770805aee524bee928"
 dependencies = [
  "serde",
  "serde_yaml 0.8.26",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.18"
+version = "0.7.19"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"
@@ -25,7 +25,7 @@ serde = { version = "1.0.206", features = ["derive"] }
 serde_json = "1.0.124"
 serde_yaml = "0.9.33"
 shellexpand = "3.1.0"
-shrub-rs = "0.5.3"
+shrub-rs = "0.5.4"
 tokio = { version = "1.39.2", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json", "fmt", "std"] }


### PR DESCRIPTION
Context
---

Incorporating this change https://github.com/evergreen-ci/shrub-rs/pull/4

Testing
---

Verified locally that `ec2.assume_role` command doesn't cause parsing errors:

```diff
diff --git a/etc/evergreen_yml_components/tasks/misc_tasks.yml b/etc/evergreen_yml_components/tasks/misc_tasks.yml
index da78b325672..08f34c72f61 100644
--- a/etc/evergreen_yml_components/tasks/misc_tasks.yml
+++ b/etc/evergreen_yml_components/tasks/misc_tasks.yml
@@ -1576,3 +1576,11 @@ tasks:
       - func: "set up venv"
       - func: "upload pip requirements"
       - func: "generate version validation"
+
+  - name: test_ec2_assume_role_command
+    commands:
+      - command: ec2.assume_role
+        params:
+          role_arn: "${ecr_role_arn}"
+          policy: "{}"
+          duration_seconds: 900
```

```bash
mongo % ../mongo-task-generator/target/debug/mongo-task-generator --expansion-file expansions.yml --evg-auth-file ~/.evergreen.yml --evg-project-file etc/evergreen.yml --generate-sub-tasks-config etc/generate_subtasks_config.yml --resmoke-command "poetry run python buildscripts/resmoke.py" --use-task-split-fallback
{"timestamp":"2024-11-18T14:18:37.239356Z","level":"INFO","fields":{"message":"Generating resmoke task: auth_audit_gen, is_enterprise: true, platform: linux"},"target":"mongo_task_generator"}
{"timestamp":"2024-11-18T14:18:37.239698Z","level":"INFO","fields":{"message":"Generating resmoke task: ssl_gen, is_enterprise: true, platform: linux"},"target":"mongo_task_generator"}
...
{"timestamp":"2024-11-18T14:30:54.115470Z","level":"INFO","fields":{"message":"Resmoke test discovery finished","suite_name":"fcv_upgrade_downgrade_replica_sets_jscore_passthrough","duration_ms":6506},"target":"mongo_task_generator::resmoke::resmoke_proxy"}
{"timestamp":"2024-11-18T14:30:56.665219Z","level":"INFO","fields":{"message":"Resmoke test discovery finished","suite_name":"change_streams_last_lts_new_old_new","duration_ms":3324},"target":"mongo_task_generator::resmoke::resmoke_proxy"}
{"timestamp":"2024-11-18T14:31:13.493103Z","level":"INFO","fields":{"message":"generation completed: 756 seconds"},"target":"mongo_task_generator"}
```