### PR TITLE
DEVPROD-14172: update shrub-rs to 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.20 - 2025-01-16
+* DEVPROD-14172 Update shrub-rs dependency that includes papertrail.trace command
+
 ## 0.7.19 - 2024-11-18
 * DEVPROD-11914 Update shrub-rs dependency that includes ec2.assume_role command
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2892,9 +2892,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shrub-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eefe73155207d228f19f029620cb44a581c6e5364927770805aee524bee928"
+checksum = "85ce1399dd2ca316f71b6325f96ed882fe63a1e259862e75571e4100a56a96ea"
 dependencies = [
  "serde",
  "serde_yaml 0.8.26",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.19"
+version = "0.7.20"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"
@@ -25,7 +25,7 @@ serde = { version = "1.0.206", features = ["derive"] }
 serde_json = "1.0.124"
 serde_yaml = "0.9.33"
 shellexpand = "3.1.0"
-shrub-rs = "0.5.4"
+shrub-rs = "0.5.5"
 tokio = { version = "1.39.2", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json", "fmt", "std"] }


### PR DESCRIPTION
shrub-rs 0.5.5 has a new Evergreen command that will prevent crashes in `mongo-task-generator`