### PR TITLE
DEVPROD-14354 avoid a division-by-zero when processing empty suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.22 - 2025-01-22
+* Avoid a division-by-zero when processing empty suites.
+
 ## 0.7.21 - 2025-01-16
 * Add additional logging for task generation that takes a long time.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the mongodb/mongo project."
 license = "Apache-2.0"
-version = "0.7.21"
+version = "0.7.22"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["Decision Automation Group <dev-prod-dag@mongodb.com>"]
 edition = "2018"

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -509,15 +509,14 @@ impl GenResmokeTaskServiceImpl {
         multiversion_name: Option<&str>,
         multiversion_tags: Option<String>,
     ) -> Result<Vec<SubSuite>> {
+        let mut sub_suites = vec![];
+
         let origin_suite = multiversion_name.unwrap_or(&params.suite_name);
         let test_list = self.get_test_list(params, multiversion_name)?;
-        let n_suites = min(test_list.len(), self.config.n_suites);
-
-        let mut sub_suites = vec![];
-        if n_suites == 0 {
+        if test_list.is_empty() {
             return Ok(sub_suites);
         }
-
+        let n_suites = min(test_list.len(), self.config.n_suites);
         let tasks_per_suite = test_list.len() / n_suites;
 
         let mut current_tests = vec![];

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -512,9 +512,14 @@ impl GenResmokeTaskServiceImpl {
         let origin_suite = multiversion_name.unwrap_or(&params.suite_name);
         let test_list = self.get_test_list(params, multiversion_name)?;
         let n_suites = min(test_list.len(), self.config.n_suites);
-        let tasks_per_suite = test_list.len() / n_suites;
 
         let mut sub_suites = vec![];
+        if n_suites == 0 {
+            return Ok(sub_suites);
+        }
+
+        let tasks_per_suite = test_list.len() / n_suites;
+
         let mut current_tests = vec![];
         let mut i = 0;
         for test in test_list {
@@ -1304,6 +1309,28 @@ mod tests {
         for test_name in test_list {
             assert!(all_tests.contains(&test_name.to_string()));
         }
+    }
+
+    #[test]
+    fn test_split_task_fallback_empty_suite() {
+        let n_suites = 1;
+        let test_list = vec![];
+        let task_history = TaskRuntimeHistory {
+            task_name: "my task".to_string(),
+            test_map: hashmap! {},
+        };
+        let gen_resmoke_service =
+            build_mocked_service(test_list.clone(), task_history.clone(), n_suites);
+
+        let params = ResmokeGenParams {
+            ..Default::default()
+        };
+
+        let sub_suites = gen_resmoke_service
+            .split_task_fallback(&params, None, None)
+            .unwrap();
+
+        assert_eq!(sub_suites.len(), 0);
     }
 
     // tests for get_test_list.


### PR DESCRIPTION
The tests returned by resmoke's test discovery for a task may be empty. The codepath for splitting the task when stats from evergreen are successfully collected handles this, but the fallback method here naively did not. An empty list of sub-suites should be returned to match behavior.