### PR TITLE
DEVPROD-16742 Include fully disabled feature flags when using resmoke's test-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.24 - 2025-04-10
+* Include fully disabled feature flags when using resmoke's test-discovery
+
 ## 0.7.23 - 2025-03-17
 * Add a timeout to Evergreen test stats requests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the 10gen/mongo project."
 license = "Apache-2.0"
-version = "0.7.23"
+version = "0.7.24"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["DevProd Correctness Team <devprod-correctness-team@mongodb.com>"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ pub struct ExecutionConfiguration<'a> {
     pub gen_burn_in: bool,
     /// True if the generator should skip tests covered by more complex suites.
     pub skip_covered_tests: bool,
+    /// True if test discovery should include tests that are tagged with fully disabled features.
+    pub include_fully_disabled_feature_tests: bool,
     /// Command to execute burn_in_tests.
     pub burn_in_tests_command: &'a str,
     /// S3 endpoint to get test stats from.
@@ -169,6 +171,7 @@ impl Dependencies {
         let discovery_service = Arc::new(ResmokeProxy::new(
             execution_config.resmoke_command,
             execution_config.skip_covered_tests,
+            execution_config.include_fully_disabled_feature_tests,
         ));
         let multiversion_service = Arc::new(MultiversionServiceImpl::new(
             discovery_service.get_multiversion_config()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,10 @@ struct Args {
     #[clap(long, default_value = DEFAULT_RESMOKE_COMMAND)]
     resmoke_command: String,
 
+    /// If the generator should include tests that are tagged with fully disabled features.
+    #[clap(long)]
+    include_fully_disabled_feature_tests: bool,
+
     /// File containing configuration for generating sub-tasks.
     #[clap(long, value_parser)]
     generate_sub_tasks_config: Option<PathBuf>,
@@ -158,6 +162,7 @@ async fn main() {
         config_location: &evg_expansions.config_location(),
         gen_burn_in: args.burn_in,
         skip_covered_tests: evg_expansions.is_patch && !evg_expansions.run_covered_tests,
+        include_fully_disabled_feature_tests: args.include_fully_disabled_feature_tests,
         burn_in_tests_command: &args.burn_in_tests_command,
         s3_test_stats_endpoint: &args.s3_test_stats_endpoint,
     };

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -43,6 +43,8 @@ pub struct ResmokeProxy {
     resmoke_script: Vec<String>,
     /// True if the generator should skip tests already run in more complex suites.
     skip_covered_tests: bool,
+    /// True if test discovery should include tests that are tagged with fully disabled features.
+    include_fully_disabled_feature_tests: bool,
 }
 
 impl ResmokeProxy {
@@ -52,7 +54,12 @@ impl ResmokeProxy {
     ///
     /// * `resmoke_cmd` - Command to invoke resmoke.
     /// * `skip_covered_tests` - Whether the generator should skip tests run in more complex suites.
-    pub fn new(resmoke_cmd: &str, skip_covered_tests: bool) -> Self {
+    /// * `include_fully_disabled_feature_tests` - If the generator should include tests that are tagged with fully disabled features.
+    pub fn new(
+        resmoke_cmd: &str,
+        skip_covered_tests: bool,
+        include_fully_disabled_feature_tests: bool,
+    ) -> Self {
         let cmd_parts: Vec<_> = resmoke_cmd.split(' ').collect();
         let cmd = cmd_parts[0];
         let script = cmd_parts[1..].iter().map(|s| s.to_string()).collect();
@@ -60,6 +67,7 @@ impl ResmokeProxy {
             resmoke_cmd: cmd.to_string(),
             resmoke_script: script,
             skip_covered_tests,
+            include_fully_disabled_feature_tests,
         }
     }
 }
@@ -88,18 +96,17 @@ impl TestDiscovery for ResmokeProxy {
     fn discover_tests(&self, suite_name: &str) -> Result<Vec<String>> {
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
-        cmd.append(&mut vec![
-            "test-discovery",
-            "--suite",
-            suite_name,
-            "--includeFullyDisabledFeatureTests",
-        ]);
+        cmd.append(&mut vec!["test-discovery", "--suite", suite_name]);
 
         // When running in a patch build, we use the --skipTestsCoveredByMoreComplexSuites
         // flag to tell Resmoke to exclude any tests in the given suite that will
         // also be run on a more complex suite.
         if self.skip_covered_tests {
             cmd.append(&mut vec!["--skipTestsCoveredByMoreComplexSuites"]);
+        }
+
+        if self.include_fully_disabled_feature_tests {
+            cmd.append(&mut vec!["--includeFullyDisabledFeatureTests"]);
         }
 
         let start = Instant::now();

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -88,7 +88,12 @@ impl TestDiscovery for ResmokeProxy {
     fn discover_tests(&self, suite_name: &str) -> Result<Vec<String>> {
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
-        cmd.append(&mut vec!["test-discovery", "--suite", suite_name]);
+        cmd.append(&mut vec![
+            "test-discovery",
+            "--suite",
+            suite_name,
+            "--includeFullyDisabledFeatureTests",
+        ]);
 
         // When running in a patch build, we use the --skipTestsCoveredByMoreComplexSuites
         // flag to tell Resmoke to exclude any tests in the given suite that will


### PR DESCRIPTION
This will ensure that build variants that override fully disabled feature flags will include the tests that are expected to run.

In total, the generated suite configs in mongodb-mongo-master grow by 1.3% since they now include a few more tests, but when run, the feature flag filtering is applied as expected. Only variants that use --additionalFeatureFlags to override fully_disabled_feature_flags.yml may have a increase in what tests actually run.