### PR TITLE
DEVPROD-16911 make number of sub-tasks configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the 10gen/mongo project."
 license = "Apache-2.0"
-version = "1.0.0"
+version = "1.1.0"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["DevProd Correctness Team <devprod-correctness-team@mongodb.com>"]
 edition = "2018"
+rust-version = "1.75"
 
 [dependencies]
 anyhow = "1.0.86"

--- a/docs/generating_tasks.md
+++ b/docs/generating_tasks.md
@@ -99,7 +99,7 @@ Looking at a [sample resmoke-based](https://github.com/mongodb/mongo/blob/852c5d
 ```
 
 Like fuzzer tasks, task generation is indicated by including the `"generate resmoke tasks"` function.
-Additionally, the 3 parameters here will impact how the task is generated.
+Additionally, the 4 parameters here will impact how the task is generated.
 
 * **suite**: By default, the name of the task (with the `_gen` suffix stripped off) will be used
   to determine which resmoke suite to base the generated sub-tasks on. This can be overwritten with
@@ -112,6 +112,7 @@ Additionally, the 3 parameters here will impact how the task is generated.
   variable is set to `"true"`, certain tasks will use an even larger distro that can be defined with
   the `xlarge_distro_name` expansion in the build variant. When the `xlarge_distro_name` expansion
   is not defined, it will fallback to the defined `large_distro_name` expansion in the build variant
+* **num_tasks**: The number of generated sub-tasks to split into. (Default 5).
 
 **Note**: If a task has the `use_large_distro` value defined, but is added to a build variant
 without a `large_distro_name`, it will trigger a failure. This can be supported by using the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ mod utils;
 const BURN_IN_TESTS_PREFIX: &str = "burn_in_tests";
 const BURN_IN_TASKS_PREFIX: &str = "burn_in_tasks";
 const BURN_IN_BV_SUFFIX: &str = "generated-by-burn-in-tags";
-const MAX_SUB_TASKS_PER_TASK: usize = 5;
+const DEFAULT_SUB_TASKS_PER_TASK: usize = 5;
 
 type GenTaskCollection = HashMap<String, Box<dyn GeneratedSuite>>;
 
@@ -206,11 +206,8 @@ impl Dependencies {
                 32,
             )));
         let enterprise_dir = evg_config_service.get_module_dir(ENTERPRISE_MODULE);
-        let gen_resmoke_config = GenResmokeConfig::new(
-            MAX_SUB_TASKS_PER_TASK,
-            execution_config.use_task_split_fallback,
-            enterprise_dir,
-        );
+        let gen_resmoke_config =
+            GenResmokeConfig::new(execution_config.use_task_split_fallback, enterprise_dir);
         let gen_resmoke_task_service = Arc::new(GenResmokeTaskServiceImpl::new(
             task_history_service,
             discovery_service,

--- a/src/services/config_extraction.rs
+++ b/src/services/config_extraction.rs
@@ -18,6 +18,7 @@ use crate::{
         multiversion::MultiversionService, resmoke_tasks::ResmokeGenParams,
     },
     utils::task_name::remove_gen_suffix,
+    DEFAULT_SUB_TASKS_PER_TASK,
 };
 
 /// Interface for performing extractions of evergreen project configuration.
@@ -248,6 +249,13 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
                 .evg_config_utils
                 .lookup_build_variant_expansion(UNIQUE_GEN_SUFFIX_EXPANSION, variant);
         }
+        let num_tasks = match self
+            .evg_config_utils
+            .get_gen_task_var(task_def, "num_tasks")
+        {
+            Some(str) => str.parse().unwrap(),
+            _ => DEFAULT_SUB_TASKS_PER_TASK,
+        };
 
         Ok(ResmokeGenParams {
             task_name,
@@ -289,6 +297,7 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
             pass_through_vars: self.evg_config_utils.get_gen_task_vars(task_def),
             platform,
             gen_task_suffix,
+            num_tasks,
         })
     }
 

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -77,7 +77,7 @@ pub struct ResmokeGenParams {
     pub platform: Option<String>,
     /// Name of variant specific suffix to add to tasks
     pub gen_task_suffix: Option<String>,
-    /// Number of sub-tasks fuzzer should generate.
+    /// Number of sub-tasks to generate.
     pub num_tasks: usize,
 }
 
@@ -1365,7 +1365,7 @@ mod tests {
 
         let sub_suites = gen_resmoke_service
             .split_task_fallback(&params, None, None)
-            .unwrap();
+            .unwrap();n
 
         assert_eq!(sub_suites.len(), 0);
     }

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -1365,7 +1365,7 @@ mod tests {
 
         let sub_suites = gen_resmoke_service
             .split_task_fallback(&params, None, None)
-            .unwrap();n
+            .unwrap();
 
         assert_eq!(sub_suites.len(), 0);
     }

--- a/tests/data/evergreen.yml
+++ b/tests/data/evergreen.yml
@@ -4211,6 +4211,7 @@ tasks:
       use_large_distro: "true"
       resmoke_jobs_max: 1
       resmoke_repeat_suites: 5
+      num_tasks: 10
 
 - <<: *task_template
   name: aggregation_sharded_collections_passthrough
@@ -4242,6 +4243,8 @@ tasks:
   tags: ["auth"]
   commands:
   - func: "generate resmoke tasks"
+    vars:
+      num_tasks: 2
 
 - name: burn_in_tags_gen
   tags: []

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31,7 +31,7 @@ fn test_end2end_execution() {
     assert!(tmp_dir_path.exists());
 
     let files = std::fs::read_dir(tmp_dir_path).unwrap();
-    assert_eq!(686, files.into_iter().collect::<Vec<_>>().len());
+    assert_eq!(688, files.into_iter().collect::<Vec<_>>().len());
 }
 
 #[test]


### PR DESCRIPTION
This extends the capability for configuring the number of sub-tasks to all generated task types (previously this was only available for fuzzer tasks). The number of generated subtasks is now configurable using `num_tasks`, with the default still being to use 5.

Usage:
```
- <<: *gen_task_template
  name: auth_gen
  tags: ["auth"]
  commands:
  - func: "generate resmoke tasks"
    vars:
      num_tasks: 10
```