### PR TITLE
DEVPROD-17817 add dependencies for multiversion binary selection on burn-in task references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.0.1 - 2025-05-22
+* Add multiversion binary selection dependency to burn-in tasks when needed.
+
 ## 3.0.0 - 2025-05-07
 * Generate multiversion binary selection tasks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the 10gen/mongo project."
 license = "Apache-2.0"
-version = "3.0.0"
+version = "3.0.1"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["DevProd Correctness Team <devprod-correctness-team@mongodb.com>"]
 edition = "2018"


### PR DESCRIPTION
This ensures that the `select_multiversion_binaries` task is created and run when a burn-in task is multiversion. If the generated task needs to depend on `select_multiversion_binaries`, it adds the dependency to the task reference, overriding the variant-wide dependencies.