### PR TITLE
DEVPROD-31553: Update to handle older branches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.5.2 - 2026-04-14
+* Updates module logic for determining if tasks are in enterprise mode to work on older branches of MongoDB.
+
 ## 3.5.0 - 2025-8-20
 * Uses new module logic to determine if tasks are in enterprise mode
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "3.5.1"
+version = "3.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the 10gen/mongo project."
 license = "Apache-2.0"
-version = "3.5.1"
+version = "3.5.2"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["DevProd Correctness Team <devprod-correctness-team@mongodb.com>"]
 edition = "2018"

--- a/src/evergreen/evg_config_utils.rs
+++ b/src/evergreen/evg_config_utils.rs
@@ -752,10 +752,11 @@ impl EvgConfigUtils for EvgConfigUtilsImpl {
     /// true if given build variant includes the enterprise module.
     fn is_enterprise_build_variant(&self, build_variant: &BuildVariant) -> bool {
         // assumed to be true, unless explicitly disabled
+        let pre83_pattern = Regex::new(r"--enableEnterpriseTests\s*=?\s*off").unwrap();
         let pattern = Regex::new(r"--modules\s*=?\s*none").unwrap();
         if let Some(expansions_map) = &build_variant.expansions {
             for (_key, value) in expansions_map.iter() {
-                if pattern.is_match(value) {
+                if pre83_pattern.is_match(value) || pattern.is_match(value) {
                     return false;
                 }
             }

--- a/src/evergreen/evg_config_utils.rs
+++ b/src/evergreen/evg_config_utils.rs
@@ -1786,15 +1786,19 @@ mod tests {
 
     // tests for is_enterprise_build_variant.
     #[rstest]
-    #[case(None)]
-    // this flag is no longer supported: it should return true in either case
-    #[case(Some(vec!["--enableEnterpriseTests=on".to_string()]))]
-    #[case(Some(vec!["--enableEnterpriseTests=off".to_string()]))]
+    #[case(None, None)]
+    // the modules field is not checked, so these should all return true
+    #[case(Some(vec!["--enableEnterpriseTests=on".to_string()]), None)]
+    #[case(Some(vec!["--enableEnterpriseTests=off".to_string()]), None)]
+    // enableEnterpriseTests=on in expansions should still be enterprise
+    #[case(None, Some(btreemap! { "resmoke_args".to_string() => "--enableEnterpriseTests=on".to_string() }))]
     fn test_build_variant_with_enterprise_module_should_return_true(
         #[case] modules: Option<Vec<String>>,
+        #[case] expansions: Option<BTreeMap<String, String>>,
     ) {
         let build_variant = BuildVariant {
             modules,
+            expansions,
             ..Default::default()
         };
         let evg_config_utils = EvgConfigUtilsImpl::new();
@@ -1802,11 +1806,19 @@ mod tests {
         assert!(evg_config_utils.is_enterprise_build_variant(&build_variant));
     }
 
-    #[test]
-    fn test_build_variant_with_out_enterprise_module_should_return_false() {
+    #[rstest]
+    #[case("--modules=none")]
+    #[case("--modules none")]
+    // pre-8.3 pattern for disabling enterprise
+    #[case("--enableEnterpriseTests=off")]
+    #[case("--enableEnterpriseTests off")]
+    #[case("--enableEnterpriseTests = off")]
+    fn test_build_variant_with_out_enterprise_module_should_return_false(
+        #[case] expansion_value: &str,
+    ) {
         let build_variant = BuildVariant {
             expansions: Some(btreemap! {
-                "expansion".to_string() => "--modules=none".to_string(),
+                "resmoke_args".to_string() => expansion_value.to_string(),
             }),
             ..Default::default()
         };

--- a/src/evergreen/evg_config_utils.rs
+++ b/src/evergreen/evg_config_utils.rs
@@ -1786,18 +1786,12 @@ mod tests {
 
     // tests for is_enterprise_build_variant.
     #[rstest]
-    #[case(None, None)]
-    // the modules field is not checked, so these should all return true
-    #[case(Some(vec!["--enableEnterpriseTests=on".to_string()]), None)]
-    #[case(Some(vec!["--enableEnterpriseTests=off".to_string()]), None)]
-    // enableEnterpriseTests=on in expansions should still be enterprise
-    #[case(None, Some(btreemap! { "resmoke_args".to_string() => "--enableEnterpriseTests=on".to_string() }))]
+    #[case(None)]
+    #[case(Some(btreemap! { "test_flags".to_string() => "--enableEnterpriseTests=on".to_string() }))]
     fn test_build_variant_with_enterprise_module_should_return_true(
-        #[case] modules: Option<Vec<String>>,
         #[case] expansions: Option<BTreeMap<String, String>>,
     ) {
         let build_variant = BuildVariant {
-            modules,
             expansions,
             ..Default::default()
         };
@@ -1807,18 +1801,19 @@ mod tests {
     }
 
     #[rstest]
-    #[case("--modules=none")]
-    #[case("--modules none")]
+    #[case("resmoke_args", "--modules=none")]
+    #[case("resmoke_args", "--modules none")]
     // pre-8.3 pattern for disabling enterprise
-    #[case("--enableEnterpriseTests=off")]
-    #[case("--enableEnterpriseTests off")]
-    #[case("--enableEnterpriseTests = off")]
+    #[case("test_flags", "--enableEnterpriseTests=off")]
+    #[case("test_flags", "--enableEnterpriseTests off")]
+    #[case("test_flags", "--enableEnterpriseTests = off")]
     fn test_build_variant_with_out_enterprise_module_should_return_false(
+        #[case] expansion_key: &str,
         #[case] expansion_value: &str,
     ) {
         let build_variant = BuildVariant {
             expansions: Some(btreemap! {
-                "resmoke_args".to_string() => expansion_value.to_string(),
+                expansion_key.to_string() => expansion_value.to_string(),
             }),
             ..Default::default()
         };


### PR DESCRIPTION
This brings back the old regex used to determine
is_enterprise_build_variant. This is necessary to function on branches before 8.3, which we need to do so that we can use the latest changes to mongo-task-generator in those branches.