### PR TITLE
Add last_patch multiversion old-version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.6.0 - 2026-06-09
+* Recognize `last_patch` as a multiversion old-version value. Tasks whose `initialize multiversion tasks` variables target `last_patch` now generate sub-tasks when a build variant opts in via the `last_versions` expansion, reusing the default required-FCV exclude tags.
+
 ## 3.5.2 - 2026-04-14
 * Updates module logic for determining if tasks are in enterprise mode to work on older branches of MongoDB.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "3.5.2"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the 10gen/mongo project."
 license = "Apache-2.0"
-version = "3.5.2"
+version = "3.6.0"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["DevProd Test Infrastructure Team <devprod-test-infrastructure-team@mongodb.com>"]
 edition = "2018"

--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -138,6 +138,8 @@ pub const MULTIVERSION_EXCLUDE_TAGS_FILE: &str = "multiversion_exclude_tags.yml"
 pub const MULTIVERSION_LAST_LTS: &str = "last_lts";
 /// Name of last continuous configuration.
 pub const MULTIVERSION_LAST_CONTINUOUS: &str = "last_continuous";
+/// Name of last patch configuration.
+pub const MULTIVERSION_LAST_PATCH: &str = "last_patch";
 
 // Distro group names
 /// Windows distro group name.

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -276,6 +276,14 @@ impl MultiversionConfig {
             self.requires_fcv_tag.clone()
         }
     }
+
+    /// Get the required FCV tag for the last patch version.
+    ///
+    /// `last_patch` runs against the latest patch release of the current version, whose FCV
+    /// matches the version under test, so the default `requires_fcv_tag` set applies.
+    pub fn get_fcv_tags_for_patch(&self) -> String {
+        self.requires_fcv_tag.clone()
+    }
 }
 
 #[cfg(test)]

--- a/src/task_types/multiversion.rs
+++ b/src/task_types/multiversion.rs
@@ -9,6 +9,8 @@
 //!
 //! - `lts` - Long-Term Support. This refers to the yearly, major release of MongoDB (e.g. 5.0, 6.0, ...).
 //! - `continuous` - Continuous release. This refers to the quarterly releases of MongoDB (e.g. 5.1, 5.2, 5.3, ...).
+//! - `last_patch` - The latest patch release of the current version. Its FCV matches the version
+//!   under test, so the default required-FCV exclude tags apply.
 //! - `old versions` - The previous releases on MongoDB to test against. If the previous release was
 //!   a `lts` release, only that needs to be tested against. If the previous release was not
 //!   a `lts` release, then we should test against both that release and the last `lts` release.
@@ -23,7 +25,7 @@ use crate::{
     evergreen::evg_config_utils::MultiversionGenerateTaskConfig,
     evergreen_names::{
         BACKPORT_REQUIRED_TAG, MULTIVERSION_INCOMPATIBLE, MULTIVERSION_LAST_CONTINUOUS,
-        MULTIVERSION_LAST_LTS,
+        MULTIVERSION_LAST_LTS, MULTIVERSION_LAST_PATCH,
     },
     resmoke::resmoke_proxy::MultiversionConfig,
 };
@@ -96,6 +98,7 @@ impl MultiversionService for MultiversionServiceImpl {
                 MULTIVERSION_LAST_CONTINUOUS => {
                     self.multiversion_config.get_fcv_tags_for_continuous()
                 }
+                MULTIVERSION_LAST_PATCH => self.multiversion_config.get_fcv_tags_for_patch(),
                 _ => panic!("Unknown multiversion mode: {}", &mode),
             }
         } else {
@@ -208,6 +211,58 @@ mod tests {
             multiversion_generate_tasks[1]
         );
     }
+    #[test]
+    fn test_multiversion_generate_tasks_last_patch_survives_filter() {
+        let multiversion_generate_tasks = vec![
+            MultiversionGenerateTaskConfig {
+                suite_name: "suite_last_lts".to_string(),
+                old_version: "last_lts".to_string(),
+                bazel_target: None,
+            },
+            MultiversionGenerateTaskConfig {
+                suite_name: "suite_last_patch".to_string(),
+                old_version: "last_patch".to_string(),
+                bazel_target: None,
+            },
+        ];
+        let multiversion_service = MultiversionServiceImpl {
+            multiversion_config: MultiversionConfig {
+                last_versions: vec!["last_lts".to_string(), "last_continuous".to_string()],
+                requires_fcv_tag: "requires_fcv_71".to_string(),
+                requires_fcv_tag_lts: Some("requires_fcv_71".to_string()),
+                requires_fcv_tag_continuous: Some("requires_fcv_71".to_string()),
+            },
+        };
+        // Only the variant-level `last_versions` override pulls last_patch into the filter set;
+        // the global default (last_lts, last_continuous) would otherwise drop it.
+        let filtered = multiversion_service
+            .filter_multiversion_generate_tasks(
+                Some(multiversion_generate_tasks.clone()),
+                Some("last_patch".to_string()),
+            )
+            .unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0], multiversion_generate_tasks[1]);
+    }
+
+    #[test]
+    fn test_exclude_tags_for_last_patch_uses_default_fcv_tag() {
+        let multiversion_service = MultiversionServiceImpl {
+            multiversion_config: MultiversionConfig {
+                last_versions: vec!["last_lts".to_string()],
+                requires_fcv_tag: "requires_fcv_71".to_string(),
+                requires_fcv_tag_lts: Some("requires_fcv_lts".to_string()),
+                requires_fcv_tag_continuous: Some("requires_fcv_continuous".to_string()),
+            },
+        };
+        // last_patch reuses the default `requires_fcv_tag`, not the lts/continuous tag sets.
+        let exclude_tags =
+            multiversion_service.exclude_tags_for_task("my_task", Some("last_patch".to_string()));
+        assert!(exclude_tags.contains("requires_fcv_71"));
+        assert!(!exclude_tags.contains("requires_fcv_lts"));
+        assert!(!exclude_tags.contains("requires_fcv_continuous"));
+    }
+
     #[test]
     fn test_multiversion_generate_tasks_none() {
         let multiversion_service = MultiversionServiceImpl {


### PR DESCRIPTION
Recognize `last_patch` as a multiversion old-version value alongside `last_lts` and `last_continuous`. Tasks whose `initialize multiversion tasks` variables target `last_patch` now generate sub-tasks when a build variant opts in via the `last_versions` expansion, reusing the default `requires_fcv_tag` exclude tags (last_patch FCV matches the version under test).

Bumps version to 3.6.0.