### PR TITLE
SERVER-131624: Cache resmoke test discovery results per suite

### DIFF
--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -155,13 +155,18 @@ impl TestDiscovery for ResmokeProxy {
     /// A list of tests belonging to given suite.
     fn discover_tests(&self, suite_name: &str) -> Result<Vec<String>> {
         let entry = {
-            let mut cache = self.discovery_cache.lock().unwrap();
+            // Recover from a poisoned lock (a panic in another discovery thread)
+            // rather than failing the whole generation over a cache optimization.
+            let mut cache = self
+                .discovery_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             cache
                 .entry(suite_name.to_string())
                 .or_insert_with(|| Arc::new(Mutex::new(None)))
                 .clone()
         };
-        let mut entry = entry.lock().unwrap();
+        let mut entry = entry.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(tests) = entry.as_ref() {
             return Ok(tests.clone());
         }
@@ -326,15 +331,22 @@ mod tests {
     // tests for discover_tests caching.
     #[test]
     fn test_discover_tests_only_runs_discovery_once_per_suite() {
-        let tmp_dir =
-            std::env::temp_dir().join(format!("resmoke_proxy_cache_test_{}", std::process::id()));
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "resmoke_proxy_cache_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         std::fs::create_dir_all(&tmp_dir).unwrap();
         let counter_file = tmp_dir.join("calls.txt");
+        let _ = std::fs::remove_file(&counter_file);
         let script_file = tmp_dir.join("fake_resmoke.sh");
         std::fs::write(
             &script_file,
             format!(
-                "echo called >> {}\necho 'suite_name: my_suite'\necho 'tests: []'\n",
+                "echo called >> \"{}\"\necho 'suite_name: my_suite'\necho 'tests: []'\n",
                 counter_file.display()
             ),
         )

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -1,4 +1,9 @@
-use std::{path::Path, str::FromStr, time::Instant};
+use std::{
+    path::Path,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -49,6 +54,13 @@ pub struct ResmokeProxy {
     /// True if test discovery should include tests that are tagged with fully disabled features.
     include_fully_disabled_feature_tests: bool,
     bazel_suite_configs: BazelConfigs,
+    /// Cache of test discovery results, keyed by suite name. The same suite is queried
+    /// several times per run (once per multiversion/variant combination) and discovery
+    /// shells out to resmoke, so repeat lookups are worth avoiding. Each entry has its
+    /// own lock so identical concurrent lookups wait for the first one instead of
+    /// spawning duplicate resmoke processes, while lookups of different suites proceed
+    /// in parallel.
+    discovery_cache: Arc<Mutex<HashMap<String, Arc<Mutex<Option<Vec<String>>>>>>>,
 }
 
 impl ResmokeProxy {
@@ -75,6 +87,7 @@ impl ResmokeProxy {
             skip_covered_tests,
             include_fully_disabled_feature_tests,
             bazel_suite_configs,
+            discovery_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -141,6 +154,55 @@ impl TestDiscovery for ResmokeProxy {
     ///
     /// A list of tests belonging to given suite.
     fn discover_tests(&self, suite_name: &str) -> Result<Vec<String>> {
+        let entry = {
+            let mut cache = self.discovery_cache.lock().unwrap();
+            cache
+                .entry(suite_name.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(None)))
+                .clone()
+        };
+        let mut entry = entry.lock().unwrap();
+        if let Some(tests) = entry.as_ref() {
+            return Ok(tests.clone());
+        }
+        let tests = self.run_test_discovery(suite_name)?;
+        *entry = Some(tests.clone());
+        Ok(tests)
+    }
+
+    /// Get the configuration for the given suite.
+    ///
+    /// # Arguments
+    ///
+    /// * `suite_name` - Name of test suite to query.
+    ///
+    /// # Return
+    ///
+    /// Resmoke configuration for the given suite.
+    fn get_suite_config(&self, suite_name: &str) -> Result<ResmokeSuiteConfig> {
+        let suite_config = if is_bazel_suite(suite_name) {
+            self.bazel_suite_configs.get(suite_name)
+        } else {
+            suite_name
+        };
+
+        let mut cmd = vec![&*self.resmoke_cmd];
+        cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
+        cmd.append(&mut vec!["suiteconfig", "--suite", suite_config]);
+        let cmd_output = run_command(&cmd).unwrap();
+
+        Ok(ResmokeSuiteConfig::from_str(&cmd_output)?)
+    }
+
+    /// Get the multiversion configuration to generate against.
+    fn get_multiversion_config(&self) -> Result<MultiversionConfig> {
+        MultiversionConfig::from_resmoke(&self.resmoke_cmd, &self.resmoke_script)
+    }
+}
+
+impl ResmokeProxy {
+    /// Query resmoke for the list of tests in the given suite.
+    fn run_test_discovery(&self, suite_name: &str) -> Result<Vec<String>> {
         let suite_config = if is_bazel_suite(suite_name) {
             self.bazel_suite_configs.get(suite_name)
         } else {
@@ -187,35 +249,6 @@ impl TestDiscovery for ResmokeProxy {
             .into_iter()
             .filter(|f| Path::new(f).exists())
             .collect())
-    }
-
-    /// Get the configuration for the given suite.
-    ///
-    /// # Arguments
-    ///
-    /// * `suite_name` - Name of test suite to query.
-    ///
-    /// # Return
-    ///
-    /// Resmoke configuration for the given suite.
-    fn get_suite_config(&self, suite_name: &str) -> Result<ResmokeSuiteConfig> {
-        let suite_config = if is_bazel_suite(suite_name) {
-            self.bazel_suite_configs.get(suite_name)
-        } else {
-            suite_name
-        };
-
-        let mut cmd = vec![&*self.resmoke_cmd];
-        cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
-        cmd.append(&mut vec!["suiteconfig", "--suite", suite_config]);
-        let cmd_output = run_command(&cmd).unwrap();
-
-        Ok(ResmokeSuiteConfig::from_str(&cmd_output)?)
-    }
-
-    /// Get the multiversion configuration to generate against.
-    fn get_multiversion_config(&self) -> Result<MultiversionConfig> {
-        MultiversionConfig::from_resmoke(&self.resmoke_cmd, &self.resmoke_script)
     }
 }
 
@@ -289,6 +322,42 @@ impl MultiversionConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // tests for discover_tests caching.
+    #[test]
+    fn test_discover_tests_only_runs_discovery_once_per_suite() {
+        let tmp_dir =
+            std::env::temp_dir().join(format!("resmoke_proxy_cache_test_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let counter_file = tmp_dir.join("calls.txt");
+        let script_file = tmp_dir.join("fake_resmoke.sh");
+        std::fs::write(
+            &script_file,
+            format!(
+                "echo called >> {}\necho 'suite_name: my_suite'\necho 'tests: []'\n",
+                counter_file.display()
+            ),
+        )
+        .unwrap();
+        let proxy = ResmokeProxy::new(
+            &format!("sh {}", script_file.display()),
+            false,
+            false,
+            BazelConfigs::default(),
+        );
+
+        for _ in 0..3 {
+            assert_eq!(
+                proxy.discover_tests("my_suite").unwrap(),
+                Vec::<String>::new()
+            );
+        }
+        proxy.discover_tests("other_suite").unwrap();
+
+        let calls = std::fs::read_to_string(&counter_file).unwrap();
+        assert_eq!(calls.lines().count(), 2);
+        std::fs::remove_dir_all(&tmp_dir).unwrap();
+    }
 
     // tests for get_fcv_tags_for_lts.
     #[test]

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -60,8 +60,12 @@ pub struct ResmokeProxy {
     /// own lock so identical concurrent lookups wait for the first one instead of
     /// spawning duplicate resmoke processes, while lookups of different suites proceed
     /// in parallel.
-    discovery_cache: Arc<Mutex<HashMap<String, Arc<Mutex<Option<Vec<String>>>>>>>,
+    discovery_cache: DiscoveryCache,
 }
+
+/// Cache of test discovery results, keyed by suite name. Each entry has its own
+/// lock so identical concurrent lookups share one resmoke invocation.
+type DiscoveryCache = Arc<Mutex<HashMap<String, Arc<Mutex<Option<Vec<String>>>>>>>;
 
 impl ResmokeProxy {
     /// Create a new `ResmokeProxy` instance.

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -194,7 +194,7 @@ impl TestDiscovery for ResmokeProxy {
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
         cmd.append(&mut vec!["suiteconfig", "--suite", suite_config]);
-        let cmd_output = run_command(&cmd).unwrap();
+        let cmd_output = run_command(&cmd)?;
 
         Ok(ResmokeSuiteConfig::from_str(&cmd_output)?)
     }
@@ -230,7 +230,7 @@ impl ResmokeProxy {
         }
 
         let start = Instant::now();
-        let cmd_output = run_command(&cmd).unwrap();
+        let cmd_output = run_command(&cmd)?;
 
         event!(
             Level::INFO,
@@ -329,6 +329,8 @@ mod tests {
     use super::*;
 
     // tests for discover_tests caching.
+    // Uses `sh` and shell redirection, so restrict to Unix platforms.
+    #[cfg(unix)]
     #[test]
     fn test_discover_tests_only_runs_discovery_once_per_suite() {
         let tmp_dir = std::env::temp_dir().join(format!(


### PR DESCRIPTION
Add support for repeating `--suite` on `resmoke.py test-discovery`. When multiple suites are given, discovery for all of them runs in a single resmoke invocation and the output is a multi-document YAML stream (one `SuiteTestList` document per suite, in request order). A single `--suite` keeps the historical single-document output, so existing callers are unaffected.

Why: mongo-task-generator runs `test-discovery` once per generated suite (~377 unique suites on mongodb-mongo-master), and each invocation pays ~2s of resmoke import/startup for ~100ms of actual discovery work — about 13 CPU-minutes per `version_gen` run, ~2,160 runs/week. Batching lets the generator amortize the startup cost across all suites (measured: 323 suites discovered in ~30s vs ~11 minutes of CPU).

Changes are confined to `buildscripts/resmokelib/discovery/__init__.py` (`TestDiscoverySubcommand` accepts a list; `--suite` uses `action="append"`) plus unit tests in `buildscripts/tests/resmokelib/discovery/test_discovery.py` covering the multi-document output.

The consuming generator change is mongodb/mongo-task-generator#TBD (`--batch-test-discovery`); the generator flag will only be enabled on branches whose resmoke has this change.
