### PR TITLE
SERVER-131624: Add --batch-test-discovery and cache suiteconfig results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ use evergreen::{
 };
 use evergreen_names::{
     BURN_IN_TAGS, BURN_IN_TAG_COMPILE_TASK_DEPENDENCY, BURN_IN_TAG_INCLUDE_BUILD_VARIANTS,
-    BURN_IN_TASKS, BURN_IN_TESTS, ENTERPRISE_MODULE, GENERATOR_TASKS,
-    MULTIVERSION_BINARY_SELECTION, UNIQUE_GEN_SUFFIX_EXPANSION,
+    BURN_IN_TASKS, BURN_IN_TESTS, ENTERPRISE_MODULE, GENERATOR_TASKS, MULTIVERSION,
+    MULTIVERSION_BINARY_SELECTION, NO_MULTIVERSION_GENERATE_TASKS, UNIQUE_GEN_SUFFIX_EXPANSION,
 };
 use generate_sub_tasks_config::GenerateSubTasksConfig;
 use resmoke::{
@@ -151,6 +151,8 @@ pub struct ExecutionConfiguration<'a> {
     pub s3_test_stats_bucket: &'a str,
     pub subtask_limits: SubtaskLimits,
     pub bazel_suite_configs: Option<PathBuf>,
+    /// True if all suites should be discovered up front with batched resmoke calls.
+    pub batch_test_discovery: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -174,9 +176,12 @@ pub struct SubtaskLimits {
 #[derive(Clone)]
 pub struct Dependencies {
     evg_config_utils: Arc<dyn EvgConfigUtils>,
+    evg_config_service: Arc<dyn EvgConfigService>,
+    test_discovery: Arc<dyn TestDiscovery>,
     gen_task_service: Arc<dyn GenerateTasksService>,
     resmoke_config_actor: Arc<tokio::sync::Mutex<dyn ResmokeConfigActor>>,
     burn_in_service: Arc<dyn BurnInService>,
+    batch_test_discovery: bool,
 }
 
 impl Dependencies {
@@ -239,7 +244,7 @@ impl Dependencies {
             GenResmokeConfig::new(execution_config.use_task_split_fallback, enterprise_dir);
         let gen_resmoke_task_service = Arc::new(GenResmokeTaskServiceImpl::new(
             task_history_service,
-            discovery_service,
+            discovery_service.clone(),
             resmoke_config_actor.clone(),
             multiversion_service,
             fs_service,
@@ -252,7 +257,7 @@ impl Dependencies {
                 .to_string(),
         ));
         let gen_task_service = Arc::new(GenerateTasksServiceImpl::new(
-            evg_config_service,
+            evg_config_service.clone(),
             evg_config_utils.clone(),
             gen_fuzzer_service,
             gen_resmoke_task_service.clone(),
@@ -273,9 +278,12 @@ impl Dependencies {
 
         Ok(Self {
             evg_config_utils,
+            evg_config_service,
+            test_discovery: discovery_service,
             gen_task_service,
             resmoke_config_actor,
             burn_in_service,
+            batch_test_discovery: execution_config.batch_test_discovery,
         })
     }
 }
@@ -299,6 +307,54 @@ impl GeneratedConfig {
     }
 }
 
+/// Discover the tests of every resmoke-generated suite up front with batched resmoke
+/// invocations, seeding the test discovery cache.
+///
+/// Multiversion-specific suite names are not known at this point; they are discovered
+/// lazily (and deduplicated by the cache) during generation.
+fn prewarm_test_discovery(deps: &Dependencies) -> Result<()> {
+    let task_map = deps.evg_config_service.get_task_def_map();
+    let mut suites: Vec<String> = task_map
+        .values()
+        .filter(|task_def| {
+            // Fuzzer tasks share the "generate resmoke tasks" function but their "suite"
+            // var names a fuzzer configuration, not a resmoke suite, and fuzzer
+            // generation never runs test discovery. Multiversion-generate tasks only
+            // ever discover their per-old-version suite names, which are not known
+            // here; their base suite name may not exist as a resmoke suite at all.
+            if !deps.evg_config_utils.is_task_generated(task_def)
+                || deps.evg_config_utils.is_task_fuzzer(task_def)
+                || matches!(
+                    task_def.name.as_str(),
+                    BURN_IN_TESTS | BURN_IN_TASKS | BURN_IN_TAGS
+                )
+            {
+                return false;
+            }
+            let tags = deps.evg_config_utils.get_task_tags(task_def);
+            !tags.contains(MULTIVERSION) || tags.contains(NO_MULTIVERSION_GENERATE_TASKS)
+        })
+        .map(|task_def| {
+            // Bazel-based suites are discovered by their bazel target rather than the
+            // resolved suite name.
+            deps.evg_config_utils
+                .get_gen_task_var(task_def, "suite")
+                .filter(|suite| suite.starts_with("//"))
+                .unwrap_or_else(|| deps.evg_config_utils.find_suite_name(task_def))
+                .to_string()
+        })
+        .collect();
+    suites.sort();
+    suites.dedup();
+
+    event!(
+        Level::INFO,
+        num_suites = suites.len(),
+        "Prewarming test discovery cache with batched discovery"
+    );
+    deps.test_discovery.prewarm(&suites)
+}
+
 /// Create 'generate.tasks' configuration for all generated tasks in the provided evergreen
 /// project configuration.
 ///
@@ -309,6 +365,10 @@ impl GeneratedConfig {
 pub async fn generate_configuration(deps: &Dependencies, target_directory: &Path) -> Result<()> {
     let generate_tasks_service = deps.gen_task_service.clone();
     std::fs::create_dir_all(target_directory)?;
+
+    if deps.batch_test_discovery {
+        prewarm_test_discovery(deps)?;
+    }
 
     // We are going to do 2 passes through the project build variants. In this first pass, we
     // are actually going to create all the generated tasks that we discover.
@@ -1365,14 +1425,37 @@ mod tests {
         }
     }
 
+    struct MockTestDiscovery {}
+    impl TestDiscovery for MockTestDiscovery {
+        fn discover_tests(&self, _suite_name: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        fn get_suite_config(
+            &self,
+            _suite_name: &str,
+        ) -> Result<crate::resmoke::resmoke_suite::ResmokeSuiteConfig> {
+            todo!()
+        }
+
+        fn get_multiversion_config(
+            &self,
+        ) -> Result<crate::resmoke::resmoke_proxy::MultiversionConfig> {
+            todo!()
+        }
+    }
+
     fn build_mocked_dependencies(burn_in_service: MockBurnInService) -> Dependencies {
         Dependencies {
             evg_config_utils: Arc::new(MockEvgConfigUtils {}),
+            evg_config_service: Arc::new(MockConfigService {}),
+            test_discovery: Arc::new(MockTestDiscovery {}),
             gen_task_service: Arc::new(build_mock_generate_tasks_service()),
             resmoke_config_actor: Arc::new(tokio::sync::Mutex::new(
                 MockResmokeConfigActorService {},
             )),
             burn_in_service: Arc::new(burn_in_service),
+            batch_test_discovery: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,11 @@ struct Args {
     /// YAML file mapping mapping bazel target names of suite configs to their file location location
     #[clap(long, value_parser)]
     bazel_suite_configs: Option<PathBuf>,
+
+    /// Discover all suites up front with batched resmoke test-discovery invocations.
+    /// Requires a resmoke version whose test-discovery accepts repeated --suite arguments.
+    #[clap(long)]
+    batch_test_discovery: bool,
 }
 
 /// Configure logging for the command execution.
@@ -186,6 +191,7 @@ async fn main() {
             large_required_task_runtime_threshold: args.large_required_task_runtime_threshold,
         },
         bazel_suite_configs: args.bazel_suite_configs.as_ref().map(|p| expand_path(p)),
+        batch_test_discovery: args.batch_test_discovery,
     };
     let s3_client = build_s3_client().await;
     let deps = Dependencies::new(execution_config, s3_client).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ struct Args {
     #[clap(long, default_value = DEFAULT_MAX_SUBTASKS_PER_TASK)]
     max_subtasks_per_task: usize,
 
-    /// YAML file mapping mapping bazel target names of suite configs to their file location location
+    /// YAML file mapping bazel target names of suite configs to their file location
     #[clap(long, value_parser)]
     bazel_suite_configs: Option<PathBuf>,
 

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -222,10 +222,20 @@ impl TestDiscovery for ResmokeProxy {
             // Documents are expected in request order. If any document is missing or
             // fails to parse, discard the whole batch rather than risk seeding results
             // under the wrong suite name; those suites are discovered lazily instead.
-            let parsed: Vec<TestDiscoveryOutput> = serde_yaml::Deserializer::from_str(&output)
+            let parsed: Vec<TestDiscoveryOutput> = match serde_yaml::Deserializer::from_str(&output)
                 .map(TestDiscoveryOutput::deserialize)
                 .collect::<Result<_, _>>()
-                .unwrap_or_default();
+            {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    error!(
+                        error = err.to_string(),
+                        suites = batch.join(","),
+                        "Failed to parse batch test discovery output; falling back to per-suite discovery"
+                    );
+                    continue;
+                }
+            };
             if parsed.len() != batch.len() {
                 error!(
                     expected = batch.len(),
@@ -506,12 +516,21 @@ mod tests {
         std::fs::remove_dir_all(&tmp_dir).unwrap();
     }
 
+    // Uses `sh` and shell redirection, so restrict to Unix platforms.
+    #[cfg(unix)]
     #[test]
     fn test_prewarm_seeds_cache_from_batched_discovery() {
-        let tmp_dir =
-            std::env::temp_dir().join(format!("resmoke_proxy_prewarm_test_{}", std::process::id()));
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "resmoke_proxy_prewarm_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         std::fs::create_dir_all(&tmp_dir).unwrap();
         let counter_file = tmp_dir.join("calls.txt");
+        let _ = std::fs::remove_file(&counter_file);
         let script_file = tmp_dir.join("fake_resmoke.sh");
         std::fs::write(
             &script_file,
@@ -552,14 +571,21 @@ mod tests {
         std::fs::remove_dir_all(&tmp_dir).unwrap();
     }
 
+    // Uses `sh` and shell redirection, so restrict to Unix platforms.
+    #[cfg(unix)]
     #[test]
     fn test_get_suite_config_only_runs_suiteconfig_once_per_suite() {
         let tmp_dir = std::env::temp_dir().join(format!(
-            "resmoke_proxy_suiteconfig_test_{}",
-            std::process::id()
+            "resmoke_proxy_suiteconfig_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
         ));
         std::fs::create_dir_all(&tmp_dir).unwrap();
         let counter_file = tmp_dir.join("calls.txt");
+        let _ = std::fs::remove_file(&counter_file);
         let script_file = tmp_dir.join("fake_resmoke.sh");
         std::fs::write(
             &script_file,

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -40,6 +40,14 @@ pub trait TestDiscovery: Send + Sync {
 
     /// Get the multiversion configuration to generate against.
     fn get_multiversion_config(&self) -> Result<MultiversionConfig>;
+
+    /// Discover the given suites ahead of time so later `discover_tests` calls are cheap.
+    ///
+    /// Best-effort: implementations may ignore this, and failures should fall back to
+    /// per-suite discovery rather than failing generation.
+    fn prewarm(&self, _suite_names: &[String]) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Implementation of `TestDiscovery` that queries details from resmoke.
@@ -61,11 +69,20 @@ pub struct ResmokeProxy {
     /// spawning duplicate resmoke processes, while lookups of different suites proceed
     /// in parallel.
     discovery_cache: DiscoveryCache,
+    /// Cache of suite configurations, keyed by suite name, with the same per-entry
+    /// locking scheme as `discovery_cache`. `suiteconfig` also costs a full resmoke
+    /// startup and is requested once per generated task while only depending on the
+    /// suite name.
+    suite_config_cache: SuiteConfigCache,
 }
 
 /// Cache of test discovery results, keyed by suite name. Each entry has its own
 /// lock so identical concurrent lookups share one resmoke invocation.
 type DiscoveryCache = Arc<Mutex<HashMap<String, Arc<Mutex<Option<Vec<String>>>>>>>;
+
+/// Cache of suite configurations, keyed by suite name, with the same per-entry
+/// locking scheme as `DiscoveryCache`.
+type SuiteConfigCache = Arc<Mutex<HashMap<String, Arc<Mutex<Option<ResmokeSuiteConfig>>>>>>;
 
 impl ResmokeProxy {
     /// Create a new `ResmokeProxy` instance.
@@ -92,6 +109,7 @@ impl ResmokeProxy {
             include_fully_disabled_feature_tests,
             bazel_suite_configs,
             discovery_cache: Arc::new(Mutex::new(HashMap::new())),
+            suite_config_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -179,6 +197,77 @@ impl TestDiscovery for ResmokeProxy {
         Ok(tests)
     }
 
+    /// Discover all the given suites with a small number of batched resmoke invocations
+    /// and seed the discovery cache with the results.
+    ///
+    /// Requires resmoke's `test-discovery` to accept repeated `--suite` arguments. Any
+    /// batch that fails is skipped: its suites are discovered lazily one-by-one later.
+    fn prewarm(&self, suite_names: &[String]) -> Result<()> {
+        const BATCH_SIZE: usize = 100;
+
+        for batch in suite_names.chunks(BATCH_SIZE) {
+            let start = Instant::now();
+            let output = match self.run_batch_test_discovery(batch) {
+                Ok(output) => output,
+                Err(err) => {
+                    error!(
+                        error = err.to_string(),
+                        suites = batch.join(","),
+                        "Batch test discovery failed; falling back to per-suite discovery"
+                    );
+                    continue;
+                }
+            };
+
+            // Documents are expected in request order. If any document is missing or
+            // fails to parse, discard the whole batch rather than risk seeding results
+            // under the wrong suite name; those suites are discovered lazily instead.
+            let parsed: Vec<TestDiscoveryOutput> = serde_yaml::Deserializer::from_str(&output)
+                .map(TestDiscoveryOutput::deserialize)
+                .collect::<Result<_, _>>()
+                .unwrap_or_default();
+            if parsed.len() != batch.len() {
+                error!(
+                    expected = batch.len(),
+                    parsed = parsed.len(),
+                    "Batch test discovery output did not match request; falling back to per-suite discovery"
+                );
+                continue;
+            }
+
+            let mut seeded = 0;
+            for (suite_name, doc) in batch.iter().zip(parsed) {
+                let tests: Vec<String> = doc
+                    .tests
+                    .into_iter()
+                    .filter(|f| Path::new(f).exists())
+                    .collect();
+                let entry = {
+                    let mut cache = self
+                        .discovery_cache
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    cache
+                        .entry(suite_name.to_string())
+                        .or_insert_with(|| Arc::new(Mutex::new(None)))
+                        .clone()
+                };
+                *entry.lock().unwrap_or_else(|e| e.into_inner()) = Some(tests);
+                seeded += 1;
+            }
+
+            event!(
+                Level::INFO,
+                batch_size = batch.len(),
+                seeded,
+                duration_ms = start.elapsed().as_millis() as u64,
+                "Batch resmoke test discovery finished"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Get the configuration for the given suite.
     ///
     /// # Arguments
@@ -189,6 +278,21 @@ impl TestDiscovery for ResmokeProxy {
     ///
     /// Resmoke configuration for the given suite.
     fn get_suite_config(&self, suite_name: &str) -> Result<ResmokeSuiteConfig> {
+        let entry = {
+            let mut cache = self
+                .suite_config_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            cache
+                .entry(suite_name.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(None)))
+                .clone()
+        };
+        let mut entry = entry.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(config) = entry.as_ref() {
+            return Ok(config.clone());
+        }
+
         let suite_config = if is_bazel_suite(suite_name) {
             self.bazel_suite_configs.get(suite_name)
         } else {
@@ -198,9 +302,18 @@ impl TestDiscovery for ResmokeProxy {
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
         cmd.append(&mut vec!["suiteconfig", "--suite", suite_config]);
+        let start = Instant::now();
         let cmd_output = run_command(&cmd)?;
+        event!(
+            Level::INFO,
+            suite_config,
+            duration_ms = start.elapsed().as_millis() as u64,
+            "Resmoke suiteconfig finished"
+        );
 
-        Ok(ResmokeSuiteConfig::from_str(&cmd_output)?)
+        let config = ResmokeSuiteConfig::from_str(&cmd_output)?;
+        *entry = Some(config.clone());
+        Ok(config)
     }
 
     /// Get the multiversion configuration to generate against.
@@ -210,17 +323,19 @@ impl TestDiscovery for ResmokeProxy {
 }
 
 impl ResmokeProxy {
-    /// Query resmoke for the list of tests in the given suite.
-    fn run_test_discovery(&self, suite_name: &str) -> Result<Vec<String>> {
-        let suite_config = if is_bazel_suite(suite_name) {
-            self.bazel_suite_configs.get(suite_name)
-        } else {
-            suite_name
-        };
-
+    /// Build a `test-discovery` command line covering the given suites.
+    fn test_discovery_command<'a>(&'a self, suite_names: &[&'a str]) -> Vec<&'a str> {
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
-        cmd.append(&mut vec!["test-discovery", "--suite", suite_config]);
+        cmd.push("test-discovery");
+        for suite_name in suite_names {
+            let suite_config = if is_bazel_suite(suite_name) {
+                self.bazel_suite_configs.get(suite_name)
+            } else {
+                suite_name
+            };
+            cmd.append(&mut vec!["--suite", suite_config]);
+        }
 
         // When running in a patch build, we use the --skipTestsCoveredByMoreComplexSuites
         // flag to tell Resmoke to exclude any tests in the given suite that will
@@ -233,12 +348,26 @@ impl ResmokeProxy {
             cmd.append(&mut vec!["--includeFullyDisabledFeatureTests"]);
         }
 
+        cmd
+    }
+
+    /// Run a single batched `test-discovery` invocation covering the given suites.
+    fn run_batch_test_discovery(&self, suite_names: &[String]) -> Result<String> {
+        let suite_refs: Vec<&str> = suite_names.iter().map(|s| s.as_str()).collect();
+        let cmd = self.test_discovery_command(&suite_refs);
+        run_command(&cmd)
+    }
+
+    /// Query resmoke for the list of tests in the given suite.
+    fn run_test_discovery(&self, suite_name: &str) -> Result<Vec<String>> {
+        let cmd = self.test_discovery_command(&[suite_name]);
+
         let start = Instant::now();
         let cmd_output = run_command(&cmd)?;
 
         event!(
             Level::INFO,
-            suite_config,
+            suite_name,
             duration_ms = start.elapsed().as_millis() as u64,
             "Resmoke test discovery finished"
         );
@@ -374,6 +503,91 @@ mod tests {
 
         let calls = std::fs::read_to_string(&counter_file).unwrap();
         assert_eq!(calls.lines().count(), 2);
+        std::fs::remove_dir_all(&tmp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_prewarm_seeds_cache_from_batched_discovery() {
+        let tmp_dir =
+            std::env::temp_dir().join(format!("resmoke_proxy_prewarm_test_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let counter_file = tmp_dir.join("calls.txt");
+        let script_file = tmp_dir.join("fake_resmoke.sh");
+        std::fs::write(
+            &script_file,
+            format!(
+                concat!(
+                    "echo called >> {}\n",
+                    "echo 'suite_name: suite_a'\n",
+                    "echo 'tests: []'\n",
+                    "echo '---'\n",
+                    "echo 'suite_name: suite_b'\n",
+                    "echo 'tests: []'\n",
+                ),
+                counter_file.display()
+            ),
+        )
+        .unwrap();
+        let proxy = ResmokeProxy::new(
+            &format!("sh {}", script_file.display()),
+            false,
+            false,
+            BazelConfigs::default(),
+        );
+
+        proxy
+            .prewarm(&["suite_a".to_string(), "suite_b".to_string()])
+            .unwrap();
+        assert_eq!(
+            proxy.discover_tests("suite_a").unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            proxy.discover_tests("suite_b").unwrap(),
+            Vec::<String>::new()
+        );
+
+        let calls = std::fs::read_to_string(&counter_file).unwrap();
+        assert_eq!(calls.lines().count(), 1);
+        std::fs::remove_dir_all(&tmp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_get_suite_config_only_runs_suiteconfig_once_per_suite() {
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "resmoke_proxy_suiteconfig_test_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let counter_file = tmp_dir.join("calls.txt");
+        let script_file = tmp_dir.join("fake_resmoke.sh");
+        std::fs::write(
+            &script_file,
+            format!(
+                concat!(
+                    "echo called >> {}\n",
+                    "echo 'test_kind: js_test'\n",
+                    "echo 'selector:'\n",
+                    "echo '  roots: []'\n",
+                    "echo 'executor: {{}}'\n",
+                ),
+                counter_file.display()
+            ),
+        )
+        .unwrap();
+        let proxy = ResmokeProxy::new(
+            &format!("sh {}", script_file.display()),
+            false,
+            false,
+            BazelConfigs::default(),
+        );
+
+        for _ in 0..3 {
+            proxy.get_suite_config("my_suite").unwrap();
+        }
+
+        let calls = std::fs::read_to_string(&counter_file).unwrap();
+        assert_eq!(calls.lines().count(), 1);
         std::fs::remove_dir_all(&tmp_dir).unwrap();
     }
 

--- a/src/resmoke/resmoke_proxy.rs
+++ b/src/resmoke/resmoke_proxy.rs
@@ -245,6 +245,22 @@ impl TestDiscovery for ResmokeProxy {
                 continue;
             }
 
+            // Verify each document lines up with the suite we requested at that position.
+            // Resmoke echoes back the `--suite` value as `suite_name`, so a mismatch means
+            // the output is out of order; discard the whole batch and discover lazily.
+            if let Some((suite_name, doc)) = batch
+                .iter()
+                .zip(&parsed)
+                .find(|(suite_name, doc)| self.suite_arg(suite_name) != doc.suite_name)
+            {
+                error!(
+                    expected = self.suite_arg(suite_name),
+                    actual = doc.suite_name,
+                    "Batch test discovery returned suites out of order; falling back to per-suite discovery"
+                );
+                continue;
+            }
+
             let mut seeded = 0;
             for (suite_name, doc) in batch.iter().zip(parsed) {
                 let tests: Vec<String> = doc
@@ -303,11 +319,7 @@ impl TestDiscovery for ResmokeProxy {
             return Ok(config.clone());
         }
 
-        let suite_config = if is_bazel_suite(suite_name) {
-            self.bazel_suite_configs.get(suite_name)
-        } else {
-            suite_name
-        };
+        let suite_config = self.suite_arg(suite_name);
 
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
@@ -333,18 +345,23 @@ impl TestDiscovery for ResmokeProxy {
 }
 
 impl ResmokeProxy {
+    /// Resolve the value passed as resmoke's `--suite` argument for the given suite.
+    /// For bazel suites this is the generated suite config path; otherwise the suite name.
+    fn suite_arg<'a>(&'a self, suite_name: &'a str) -> &'a str {
+        if is_bazel_suite(suite_name) {
+            self.bazel_suite_configs.get(suite_name)
+        } else {
+            suite_name
+        }
+    }
+
     /// Build a `test-discovery` command line covering the given suites.
     fn test_discovery_command<'a>(&'a self, suite_names: &[&'a str]) -> Vec<&'a str> {
         let mut cmd = vec![&*self.resmoke_cmd];
         cmd.append(&mut self.resmoke_script.iter().map(|s| s.as_str()).collect());
         cmd.push("test-discovery");
         for suite_name in suite_names {
-            let suite_config = if is_bazel_suite(suite_name) {
-                self.bazel_suite_configs.get(suite_name)
-            } else {
-                suite_name
-            };
-            cmd.append(&mut vec!["--suite", suite_config]);
+            cmd.append(&mut vec!["--suite", self.suite_arg(suite_name)]);
         }
 
         // When running in a patch build, we use the --skipTestsCoveredByMoreComplexSuites


### PR DESCRIPTION
## What
Stacked on #115. Two changes:

1. **`--batch-test-discovery` flag** (`src/main.rs`, `src/lib.rs`, `src/resmoke/resmoke_proxy.rs`): before generation, collect the suite of every resmoke-generated task (bazel targets included; fuzzer, multiversion-generate, and burn_in tasks excluded since their "suite" is not a plain resmoke suite), dedupe, and discover them via batched `resmoke.py test-discovery --suite A --suite B ...` calls in chunks of 100, seeding the discovery cache from the multi-document YAML output. A failed batch logs and falls back to lazy per-suite discovery — generation cannot be broken by a bad suite. Multiversion per-old-version suites remain lazily discovered.
2. **suiteconfig cache** (`src/resmoke/resmoke_proxy.rs`): `get_suite_config` results are now memoized per suite with the same per-entry-lock scheme. `write_standard_suite` builds a fresh `ResmokeConfigCache` per generated task, so `resmoke.py suiteconfig` previously ran once per task (~800 python startups, 666s CPU measured).


## Compatibility
The flag requires resmoke `test-discovery` to accept repeated `--suite` args (10gen/mongo#58681). Branches that don't pass the flag keep exactly the old behavior; release branches pin older generator versions anyway.

## Testing
Comparing version_gen in master waterfall shows:

```
{"message":"generation completed: 338 seconds"},"target":"mongo_task_generator"}
```

With this change and using it in resmoke:
```
{"message":"generation completed: 209 seconds"},"target":"mongo_task_generator"}
```
