### PR TITLE
DEVPROD-36071: Stop emitting gen_task_config_location in generated tasks

### DIFF
--- a/src/evergreen_names.rs
+++ b/src/evergreen_names.rs
@@ -73,8 +73,6 @@ pub const RESMOKE_ARGS: &str = "resmoke_args";
 pub const BAZEL_ARGS: &str = "bazel_args";
 /// Name of suite being executed.
 pub const SUITE_NAME: &str = "suite";
-/// Location where generation task configuration is stored in S3.
-pub const GEN_TASK_CONFIG_LOCATION: &str = "gen_task_config_location";
 /// Maximum amount of resmoke jobs to execute in parallel.
 pub const RESMOKE_JOBS_MAX: &str = "resmoke_jobs_max";
 /// Number of times to repeat a given resmoke suite.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,8 +139,6 @@ pub struct ExecutionConfiguration<'a> {
     pub target_directory: &'a Path,
     /// Task generating the configuration.
     pub generating_task: &'a str,
-    /// Location in S3 where generated configuration will be uploaded.
-    pub config_location: &'a str,
     /// Should burn_in tasks be generated.
     pub gen_burn_in: bool,
     /// True if the generator should skip tests covered by more complex suites.
@@ -219,7 +217,6 @@ impl Dependencies {
             evg_config_utils.clone(),
             multiversion_service.clone(),
             execution_config.generating_task.to_string(),
-            execution_config.config_location.to_string(),
             gen_sub_tasks_config,
         ));
         let task_history_service = Arc::new(TaskHistoryServiceImpl::new(
@@ -1146,7 +1143,6 @@ mod tests {
                 evg_config_utils,
                 Arc::new(MockMultiversionService {}),
                 "generating_task".to_string(),
-                "config_location".to_string(),
                 None,
             )),
             false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,8 @@ const DEFAULT_LARGE_REQUIRED_TASK_RUNTIME_THRESHOLD: &str = "7200";
 struct EvgExpansions {
     /// Evergreen project being run.
     pub project: String,
-    /// Git revision being run against.
-    pub revision: String,
     /// Name of task running generator.
     pub task_name: String,
-    /// ID of Evergreen version running.
-    pub version_id: String,
     /// True if the patch is a patch build.
     #[serde(default, deserialize_with = "deserialize_bool_string")]
     pub is_patch: bool,
@@ -78,14 +74,6 @@ impl EvgExpansions {
         }
 
         Ok(evg_expansions?)
-    }
-
-    /// File to store generated configuration under.
-    pub fn config_location(&self) -> String {
-        format!(
-            "{}/{}/generate_tasks/generated-config-{}.tgz",
-            self.project, self.revision, self.version_id
-        )
     }
 }
 
@@ -186,7 +174,6 @@ async fn main() {
         resmoke_command: &args.resmoke_command,
         target_directory: &expand_path(&args.target_directory),
         generating_task: &evg_expansions.task_name,
-        config_location: &evg_expansions.config_location(),
         gen_burn_in: args.burn_in,
         skip_covered_tests: evg_expansions.is_patch && !evg_expansions.run_covered_tests,
         include_fully_disabled_feature_tests: args.include_fully_disabled_feature_tests,

--- a/src/services/config_extraction.rs
+++ b/src/services/config_extraction.rs
@@ -84,7 +84,6 @@ pub struct ConfigExtractionServiceImpl {
     evg_config_utils: Arc<dyn EvgConfigUtils>,
     multiversion_service: Arc<dyn MultiversionService>,
     generating_task: String,
-    config_location: String,
     gen_sub_tasks_config: Option<GenerateSubTasksConfig>,
 }
 
@@ -95,21 +94,18 @@ impl ConfigExtractionServiceImpl {
     ///
     /// * `evg_config_utils` - Utilities for looking up evergreen project configuration.
     /// * `generating_task` - Name of task running task generation.
-    /// * `config_location` - Location where generated configuration will be stored.
     /// * `gen_sub_tasks_config` - Configuration for generating sub-tasks.
     ///
     pub fn new(
         evg_config_utils: Arc<dyn EvgConfigUtils>,
         multiversion_service: Arc<dyn MultiversionService>,
         generating_task: String,
-        config_location: String,
         gen_sub_tasks_config: Option<GenerateSubTasksConfig>,
     ) -> Self {
         Self {
             evg_config_utils,
             multiversion_service,
             generating_task,
-            config_location,
             gen_sub_tasks_config,
         }
     }
@@ -235,7 +231,6 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
                     evg_config_utils.get_multiversion_generate_tasks(task_def),
                     last_versions_expansion,
                 ),
-            config_location: self.config_location.clone(),
             dependencies: self.determine_task_dependencies(task_def),
             is_enterprise,
             platform: Some(evg_config_utils.infer_build_variant_platform(build_variant)),
@@ -330,7 +325,6 @@ impl ConfigExtractionService for ConfigExtractionServiceImpl {
                         .get_multiversion_generate_tasks(task_def),
                     last_versions_expansion,
                 ),
-            config_location: self.config_location.clone(),
             dependencies: self.determine_task_dependencies(task_def),
             is_enterprise,
             pass_through_vars: self.evg_config_utils.get_gen_task_vars(task_def),
@@ -435,7 +429,6 @@ mod tests {
             Arc::new(EvgConfigUtilsImpl::new()),
             Arc::new(MockMultiversionService {}),
             "generating_task".to_string(),
-            "config_location".to_string(),
             None,
         )
     }

--- a/src/task_types/burn_in_tests.rs
+++ b/src/task_types/burn_in_tests.rs
@@ -654,7 +654,6 @@ mod tests {
             Arc::new(EvgConfigUtilsImpl::new()),
             Arc::new(MockMultiversionService {}),
             "generating_task".to_string(),
-            "config_location".to_string(),
             None,
         )
     }

--- a/src/task_types/fuzzer_tasks.rs
+++ b/src/task_types/fuzzer_tasks.rs
@@ -13,10 +13,10 @@ use crate::{
     evergreen::evg_config_utils::MultiversionGenerateTaskConfig,
     evergreen_names::{
         ADD_GIT_TAG, CONFIGURE_EVG_API_CREDS, CONTINUE_ON_FAILURE, DO_MULTIVERSION_SETUP, DO_SETUP,
-        FUZZER_PARAMETERS, GEN_TASK_CONFIG_LOCATION, GET_PROJECT_WITH_NO_MODULES, IDLE_TIMEOUT,
-        MULTIVERSION_EXCLUDE_TAGS, NPM_COMMAND, REQUIRE_MULTIVERSION_SETUP, RESMOKE_ARGS,
-        RESMOKE_JOBS_MAX, RUN_FUZZER, RUN_GENERATED_TESTS, RUN_GENERATED_TESTS_VIA_BAZEL,
-        SETUP_JSTESTFUZZ, SHOULD_SHUFFLE_TESTS, SUITE_NAME, TASK_NAME,
+        FUZZER_PARAMETERS, GET_PROJECT_WITH_NO_MODULES, IDLE_TIMEOUT, MULTIVERSION_EXCLUDE_TAGS,
+        NPM_COMMAND, REQUIRE_MULTIVERSION_SETUP, RESMOKE_ARGS, RESMOKE_JOBS_MAX, RUN_FUZZER,
+        RUN_GENERATED_TESTS, RUN_GENERATED_TESTS_VIA_BAZEL, SETUP_JSTESTFUZZ, SHOULD_SHUFFLE_TESTS,
+        SUITE_NAME, TASK_NAME,
     },
     task_types::resmoke_tasks::replace_resmoke_args_with_bazel_args,
     utils::task_name::name_generated_task,
@@ -66,8 +66,6 @@ pub struct FuzzerGenTaskParams {
     pub require_multiversion_setup: bool,
     /// Should multiversion generate tasks exist for this.
     pub require_multiversion_generate_tasks: bool,
-    /// Location of generated task configuration.
-    pub config_location: String,
     /// List of tasks generated sub-tasks should depend on.
     pub dependencies: Vec<String>,
     /// Is this task for enterprise builds.
@@ -118,7 +116,6 @@ impl FuzzerGenTaskParams {
     ) -> HashMap<String, ParamValue> {
         let mut vars = hashmap! {
             CONTINUE_ON_FAILURE.to_string() => ParamValue::from(self.continue_on_failure),
-            GEN_TASK_CONFIG_LOCATION.to_string() => ParamValue::from(self.config_location.as_str()),
             REQUIRE_MULTIVERSION_SETUP.to_string() => ParamValue::from(self.is_multiversion()),
             RESMOKE_ARGS.to_string() => ParamValue::from(self.resmoke_args.as_str()),
             RESMOKE_JOBS_MAX.to_string() => ParamValue::from(self.resmoke_jobs_max),

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -28,9 +28,9 @@ use crate::{
     },
     evergreen_names::{
         ADD_GIT_TAG, CONFIGURE_EVG_API_CREDS, DO_MULTIVERSION_SETUP, DO_SETUP,
-        GEN_TASK_CONFIG_LOCATION, GET_PROJECT_WITH_NO_MODULES, MULTIVERSION_EXCLUDE_TAG,
-        MULTIVERSION_EXCLUDE_TAGS_FILE, REQUIRE_MULTIVERSION_SETUP, RESMOKE_ARGS, RESMOKE_JOBS_MAX,
-        RUN_GENERATED_TESTS, RUN_GENERATED_TESTS_VIA_BAZEL, SUITE_NAME,
+        GET_PROJECT_WITH_NO_MODULES, MULTIVERSION_EXCLUDE_TAG, MULTIVERSION_EXCLUDE_TAGS_FILE,
+        REQUIRE_MULTIVERSION_SETUP, RESMOKE_ARGS, RESMOKE_JOBS_MAX, RUN_GENERATED_TESTS,
+        RUN_GENERATED_TESTS_VIA_BAZEL, SUITE_NAME,
     },
     resmoke::resmoke_proxy::TestDiscovery,
     utils::{fs_service::FsService, task_name::name_generated_task},
@@ -70,8 +70,6 @@ pub struct ResmokeGenParams {
     pub bazel_args: Option<String>,
     /// Number of jobs to limit resmoke to.
     pub resmoke_jobs_max: Option<u64>,
-    /// Location where generated task configuration will be stored in S3.
-    pub config_location: String,
     /// List of tasks generated sub-tasks should depend on.
     pub dependencies: Vec<String>,
     /// Is this task for enterprise builds.
@@ -128,7 +126,6 @@ impl ResmokeGenParams {
             REQUIRE_MULTIVERSION_SETUP.to_string() => ParamValue::from(self.require_multiversion_setup),
             RESMOKE_ARGS.to_string() => ParamValue::from(resmoke_args.as_str()),
             SUITE_NAME.to_string() => ParamValue::from(suite.as_str()),
-            GEN_TASK_CONFIG_LOCATION.to_string() => ParamValue::from(self.config_location.as_str()),
         });
 
         if let Some(mv_exclude_tags) = &sub_suite.mv_exclude_tags {
@@ -958,7 +955,7 @@ mod tests {
 
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
-        assert_eq!(test_vars.len(), 4);
+        assert_eq!(test_vars.len(), 3);
         assert!(!test_vars.contains_key("resmoke_jobs_max"));
         assert_eq!(
             test_vars.get("suite").unwrap(),
@@ -985,7 +982,7 @@ mod tests {
 
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
-        assert_eq!(test_vars.len(), 5);
+        assert_eq!(test_vars.len(), 4);
         assert_eq!(
             test_vars.get("resmoke_jobs_max").unwrap(),
             &ParamValue::from(5)
@@ -1017,7 +1014,7 @@ mod tests {
         let test_vars =
             params.build_run_test_vars("my_suite_0", &sub_suite, "tag_0,tag_1,tag_2", None);
 
-        assert_eq!(test_vars.len(), 5);
+        assert_eq!(test_vars.len(), 4);
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")
@@ -1046,7 +1043,7 @@ mod tests {
 
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
-        assert_eq!(test_vars.len(), 5);
+        assert_eq!(test_vars.len(), 4);
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")
@@ -1077,7 +1074,7 @@ mod tests {
 
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
-        assert_eq!(test_vars.len(), 5);
+        assert_eq!(test_vars.len(), 4);
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -956,6 +956,7 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 3);
+        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert!(!test_vars.contains_key("resmoke_jobs_max"));
         assert_eq!(
             test_vars.get("suite").unwrap(),
@@ -983,6 +984,7 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 4);
+        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("resmoke_jobs_max").unwrap(),
             &ParamValue::from(5)
@@ -1015,6 +1017,7 @@ mod tests {
             params.build_run_test_vars("my_suite_0", &sub_suite, "tag_0,tag_1,tag_2", None);
 
         assert_eq!(test_vars.len(), 4);
+        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")
@@ -1044,6 +1047,7 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 4);
+        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")
@@ -1075,6 +1079,7 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 4);
+        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")

--- a/src/task_types/resmoke_tasks.rs
+++ b/src/task_types/resmoke_tasks.rs
@@ -956,7 +956,6 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 3);
-        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert!(!test_vars.contains_key("resmoke_jobs_max"));
         assert_eq!(
             test_vars.get("suite").unwrap(),
@@ -984,7 +983,6 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 4);
-        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("resmoke_jobs_max").unwrap(),
             &ParamValue::from(5)
@@ -1017,7 +1015,6 @@ mod tests {
             params.build_run_test_vars("my_suite_0", &sub_suite, "tag_0,tag_1,tag_2", None);
 
         assert_eq!(test_vars.len(), 4);
-        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")
@@ -1047,7 +1044,6 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 4);
-        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")
@@ -1079,7 +1075,6 @@ mod tests {
         let test_vars = params.build_run_test_vars("my_suite_0", &sub_suite, "", None);
 
         assert_eq!(test_vars.len(), 4);
-        assert!(!test_vars.contains_key("gen_task_config_location"));
         assert_eq!(
             test_vars.get("multiversion_exclude_tags_version").unwrap(),
             &ParamValue::from("last_lts")

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -112,11 +112,11 @@ fn test_end2end_burn_in_with_no_distro(#[case] config_location: String) {
 #[case("tests/data/burn_in/evergreen_burn_in_tasks_with_no_tasks.yml", 4)]
 #[case(
     "tests/data/burn_in/evergreen_burn_in_tasks_with_large_distro_task.yml",
-    315
+    305
 )]
 #[case(
     "tests/data/burn_in/evergreen_burn_in_tasks_with_non_large_distro_task.yml",
-    275
+    265
 )]
 fn test_end2end_burn_in_tasks(#[case] config_location: String, #[case] expected_num_lines: usize) {
     let mut cmd = Command::cargo_bin("mongo-task-generator").unwrap();


### PR DESCRIPTION
## What
Stop emitting the `gen_task_config_location` var into every generated task's `run generated tests`/`run tests` function vars, and remove the now-dead `config_location` plumbing (`EvgExpansions::config_location`, `ExecutionConfiguration.config_location`, `ConfigExtractionServiceImpl` field, `ResmokeGenParams`/`FuzzerGenTaskParams` fields).

## Why
The var is an identical ~160B string repeated in all ~5,400 generated task definitions — ~1MB (measured: 0.82MB BSON, 5.6%) of the mongodb-mongo-master generated config that gets appended to the parser project document. That project crossed Evergreen's 16MB threshold, forcing S3 fallback for config fetches (DEVPROD-36071).

## Safety
No supported branch consumes the expansion: the `retrieve generated test configuration` function derives the S3 path from `${project}/${revision}/${version_id}` on master and all active release branches. Only EOL v5.0 referenced `${gen_task_config_location}`, and release branches pin older generator releases regardless.

## Testing
`cargo test` passes (integration test line counts updated); verified end-to-end on a mongodb-mongo-master patch build — task succeeded and the generated config contains zero occurrences of the var.
