### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.7.0 - 2026-08-10
+* Adds a `--batch-test-discovery` flag and caches resmoke test discovery and suiteconfig results per suite.
+* Batches resmoke suiteconfig requests during prewarm.
+* Stops emitting `gen_task_config_location` in generated tasks.
+
 ## 3.6.0 - 2026-06-09
 * Recognize `last_patch` as a multiversion old-version value. Tasks whose `initialize multiversion tasks` variables target `last_patch` now generate sub-tasks when a build variant opts in via the `last_versions` expansion, reusing the default required-FCV exclude tags.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "mongo-task-generator"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mongo-task-generator"
 description = "Dynamically split evergreen tasks into subtasks for testing the 10gen/mongo project."
 license = "Apache-2.0"
-version = "3.6.0"
+version = "3.7.0"
 repository = "https://github.com/mongodb/mongo-task-generator"
 authors = ["DevProd Test Infrastructure Team <devprod-test-infrastructure-team@mongodb.com>"]
 edition = "2018"


### PR DESCRIPTION
Bumps the version to 3.7.0 and adds the changelog entry for the changes merged since v3.6.0.

The four PRs below landed without a version bump, so this is a bump-only PR rather than folding the bump into a feature PR as we usually do.

- #115 SERVER-131624: Cache resmoke test discovery results per suite
- #116 SERVER-131624: Add `--batch-test-discovery` and cache suiteconfig results
- #118 SERVER-132393: Batch resmoke suiteconfig during prewarm
- #117 DEVPROD-36071: Stop emitting `gen_task_config_location` in generated tasks

Once this merges, the release is published by tagging the merge commit `v3.7.0` and pushing the tag.
